### PR TITLE
Rename build vars

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.sh text eol=lf
 *.lib binary
 *.a binary
 *.exe binary

--- a/BuildScripts/README.md
+++ b/BuildScripts/README.md
@@ -10,10 +10,10 @@ It is adviced to keep build directory outside of repository, and avoid in-source
 
 Additional documentation describing build process can be found here: [CMake documentation](https://cmake.org/documentation).
 
-### Required: FO_SOURCE
+### Required: FO_ROOT
 Path to root directory of FOnline repository.
 
-`FO_SOURCE=FOnlineSource`
+`FO_ROOT=FOnlineSource`
 
 ### Optional: FO_FTP_DEST
 Address of FTP server where binary files will be uploaded after build.

--- a/BuildScripts/android.cache.cmake
+++ b/BuildScripts/android.cache.cmake
@@ -1,13 +1,13 @@
 # CMake initial cache
 
-if( NOT DEFINED "ENV{SOURCE_FULL_PATH}" )
-	message( FATAL_ERROR "Define SOURCE_FULL_PATH" )
+if( NOT DEFINED "ENV{ROOT_FULL_PATH}" )
+	message( FATAL_ERROR "Define ROOT_FULL_PATH" )
 endif()
 if( NOT DEFINED "ENV{ANDROID_NDK}" )
 	message( FATAL_ERROR "Define ANDROID_NDK" )
 endif()
 
-set( CMAKE_TOOLCHAIN_FILE "$ENV{SOURCE_FULL_PATH}/BuildScripts/android.toolchain.cmake" CACHE PATH "" FORCE )
+set( CMAKE_TOOLCHAIN_FILE "$ENV{ROOT_FULL_PATH}/BuildScripts/android.toolchain.cmake" CACHE PATH "" FORCE )
 set( ANDROID YES CACHE STRING "" FORCE )
 set( ANDROID_NDK $ENV{ANDROID_NDK} CACHE STRING "" FORCE )
 set( ANDROID_ABI $ENV{ANDROID_ABI} CACHE STRING "" FORCE )

--- a/BuildScripts/android.sh
+++ b/BuildScripts/android.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-[ "$FO_SOURCE" ] || { echo "FO_SOURCE is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
 [ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
 
-export SOURCE_FULL_PATH=$(cd $FO_SOURCE; pwd)
+export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 
 export ANDROID_NDK_VERSION="android-ndk-r12b"
 export ANDROID_SDK_VERSION="tools_r25.2.3"
@@ -24,7 +24,7 @@ mkdir -p android
 cd android
 
 mkdir -p "./Binaries/Client/Android" && rm -rf "./Binaries/Client/Android/*"
-cp -r "$SOURCE_FULL_PATH/BuildScripts/android-project/." "./Binaries/Client/Android"
+cp -r "$ROOT_FULL_PATH/BuildScripts/android-project/." "./Binaries/Client/Android"
 
 if [ ! -f "$ANDROID_NDK_VERSION-linux-x86_64.zip" ]; then
 	wget "https://dl.google.com/android/repository/$ANDROID_NDK_VERSION-linux-x86_64.zip"
@@ -47,13 +47,13 @@ cd $ANDROID_ABI
 
 pwd
 
-cmake -G "Unix Makefiles" -C "$SOURCE_FULL_PATH/BuildScripts/android.cache.cmake" "$SOURCE_FULL_PATH/Source"
+cmake -G "Unix Makefiles" -C "$ROOT_FULL_PATH/BuildScripts/android.cache.cmake" "$ROOT_FULL_PATH/Source"
 make -j4
 cd ../
 
 export ANDROID_ABI=x86
 mkdir -p $ANDROID_ABI
 cd $ANDROID_ABI
-cmake -G "Unix Makefiles" -C "$SOURCE_FULL_PATH/BuildScripts/android.cache.cmake" "$SOURCE_FULL_PATH/Source"
+cmake -G "Unix Makefiles" -C "$ROOT_FULL_PATH/BuildScripts/android.cache.cmake" "$ROOT_FULL_PATH/Source"
 make -j4
 cd ../

--- a/BuildScripts/android.sh
+++ b/BuildScripts/android.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
-[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT variable is not set"; exit 1; }
+[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST variable is not set"; exit 1; }
 
 export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 

--- a/BuildScripts/ios.cache.cmake
+++ b/BuildScripts/ios.cache.cmake
@@ -1,10 +1,10 @@
 # CMake initial cache
 
-if( NOT DEFINED "ENV{SOURCE_FULL_PATH}" )
-	message( FATAL_ERROR "Define SOURCE_FULL_PATH" )
+if( NOT DEFINED "ENV{ROOT_FULL_PATH}" )
+	message( FATAL_ERROR "Define ROOT_FULL_PATH" )
 endif()
 
-set( CMAKE_TOOLCHAIN_FILE "$ENV{SOURCE_FULL_PATH}/BuildScripts/ios.toolchain.cmake" CACHE PATH "" FORCE )
+set( CMAKE_TOOLCHAIN_FILE "$ENV{ROOT_FULL_PATH}/BuildScripts/ios.toolchain.cmake" CACHE PATH "" FORCE )
 set( IOS_PLATFORM "OS64" CACHE STRING "" FORCE )
 set( IOS_ARCH "arm64" CACHE STRING "" FORCE )
 set( ENABLE_BITCODE FALSE CACHE BOOL "" FORCE )

--- a/BuildScripts/ios.sh
+++ b/BuildScripts/ios.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
-[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT variable is not set"; exit 1; }
+[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST variable is not set"; exit 1; }
 
 export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 

--- a/BuildScripts/ios.sh
+++ b/BuildScripts/ios.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-[ "$FO_SOURCE" ] || { echo "FO_SOURCE is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
 [ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
 
-export SOURCE_FULL_PATH=$(cd $FO_SOURCE; pwd)
+export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 
 mkdir -p $FO_BUILD_DEST
 cd $FO_BUILD_DEST
@@ -14,5 +14,5 @@ rm -rf iOS/*
 
 pwd
 
-/Applications/CMake.app/Contents/bin/cmake -C "$SOURCE_FULL_PATH/BuildScripts/ios.cache.cmake" "$SOURCE_FULL_PATH/Source"
+/Applications/CMake.app/Contents/bin/cmake -C "$ROOT_FULL_PATH/BuildScripts/ios.cache.cmake" "$ROOT_FULL_PATH/Source"
 /Applications/CMake.app/Contents/bin/cmake --build . --config Release --target FOnline

--- a/BuildScripts/linux.sh
+++ b/BuildScripts/linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
-[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT variable is not set"; exit 1; }
+[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST variable is not set"; exit 1; }
 
 export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 

--- a/BuildScripts/linux.sh
+++ b/BuildScripts/linux.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-[ "$FO_SOURCE" ] || { echo "FO_SOURCE is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
 [ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
 
-export SOURCE_FULL_PATH=$(cd $FO_SOURCE; pwd)
+export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 
 if [[ -z "$FO_INSTALL_PACKAGES" ]]; then
 	sudo apt-get -y update || true
@@ -28,7 +28,7 @@ rm -rf ASCompiler/*
 
 mkdir -p x64
 cd x64
-cmake -G "Unix Makefiles" -C "$SOURCE_FULL_PATH/BuildScripts/linux64.cache.cmake" "$SOURCE_FULL_PATH/Source"
+cmake -G "Unix Makefiles" -C "$ROOT_FULL_PATH/BuildScripts/linux64.cache.cmake" "$ROOT_FULL_PATH/Source"
 make -j4
 cd ../
 
@@ -45,6 +45,6 @@ cd ../
 
 #mkdir -p x86
 #cd x86
-#cmake -G "Unix Makefiles" -C "$SOURCE_FULL_PATH/BuildScripts/linux32.cache.cmake" "$SOURCE_FULL_PATH/Source"
+#cmake -G "Unix Makefiles" -C "$ROOT_FULL_PATH/BuildScripts/linux32.cache.cmake" "$ROOT_FULL_PATH/Source"
 #make -j4
 #cd ../

--- a/BuildScripts/mac.sh
+++ b/BuildScripts/mac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
-[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT variable is not set"; exit 1; }
+[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST variable is not set"; exit 1; }
 
 export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 

--- a/BuildScripts/mac.sh
+++ b/BuildScripts/mac.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-[ "$FO_SOURCE" ] || { echo "FO_SOURCE is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
 [ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
 
-export SOURCE_FULL_PATH=$(cd $FO_SOURCE; pwd)
+export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 
 mkdir -p $FO_BUILD_DEST
 cd $FO_BUILD_DEST
@@ -14,5 +14,5 @@ rm -rf Mac/*
 
 pwd
 
-/Applications/CMake.app/Contents/bin/cmake -G Xcode "$SOURCE_FULL_PATH/Source"
+/Applications/CMake.app/Contents/bin/cmake -G Xcode "$ROOT_FULL_PATH/Source"
 /Applications/CMake.app/Contents/bin/cmake --build . --config RelWithDebInfo --target FOnline

--- a/BuildScripts/raspberrypi.cache.cmake
+++ b/BuildScripts/raspberrypi.cache.cmake
@@ -1,3 +1,3 @@
 # CMake initial cache
 
-set( CMAKE_TOOLCHAIN_FILE "$ENV{SOURCE_FULL_PATH}/BuildScripts/raspberrypi.toolchain.cmake" CACHE PATH "" FORCE )
+set( CMAKE_TOOLCHAIN_FILE "$ENV{ROOT_FULL_PATH}/BuildScripts/raspberrypi.toolchain.cmake" CACHE PATH "" FORCE )

--- a/BuildScripts/raspberrypi.sh
+++ b/BuildScripts/raspberrypi.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-[ "$FO_SOURCE" ] || { echo "FO_SOURCE is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
 [ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
 
-export SOURCE_FULL_PATH=$(cd $FO_SOURCE; pwd)
+export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 
 if [ -n "$FO_INSTALL_PACKAGES" ]; then
 	#sudo apt-get -y update || true
@@ -25,7 +25,7 @@ if [ ! -d "./tools" ]; then
 fi
 export PI_TOOLS_HOME=$PWD/tools
 
-cmake -G "Unix Makefiles" -C "$SOURCE_FULL_PATH/BuildScripts/raspberrypi.cache.cmake" "$SOURCE_FULL_PATH/Source"
+cmake -G "Unix Makefiles" -C "$ROOT_FULL_PATH/BuildScripts/raspberrypi.cache.cmake" "$ROOT_FULL_PATH/Source"
 make -j4
 
 if [ -n "$FO_FTP_DEST" ]; then

--- a/BuildScripts/raspberrypi.sh
+++ b/BuildScripts/raspberrypi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
-[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT variable is not set"; exit 1; }
+[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST variable is not set"; exit 1; }
 
 export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 

--- a/BuildScripts/web.cache.cmake
+++ b/BuildScripts/web.cache.cmake
@@ -1,7 +1,7 @@
 # CMake initial cache
 
-if( NOT DEFINED "ENV{SOURCE_FULL_PATH}" )
-	message( FATAL_ERROR "Define SOURCE_FULL_PATH" )
+if( NOT DEFINED "ENV{ROOT_FULL_PATH}" )
+	message( FATAL_ERROR "Define ROOT_FULL_PATH" )
 endif()
 if( NOT DEFINED "ENV{EMSCRIPTEN}" )
 	message( FATAL_ERROR "Define EMSCRIPTEN" )

--- a/BuildScripts/web.sh
+++ b/BuildScripts/web.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
-[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT variable is not set"; exit 1; }
+[ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST variable is not set"; exit 1; }
 
 export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 

--- a/BuildScripts/web.sh
+++ b/BuildScripts/web.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
-[ "$FO_SOURCE" ] || { echo "FO_SOURCE is empty"; exit 1; }
+[ "$FO_ROOT" ] || { echo "FO_ROOT is empty"; exit 1; }
 [ "$FO_BUILD_DEST" ] || { echo "FO_BUILD_DEST is empty"; exit 1; }
 
-export SOURCE_FULL_PATH=$(cd $FO_SOURCE; pwd)
+export ROOT_FULL_PATH=$(cd $FO_ROOT; pwd)
 
 export EMSCRIPTEN_VERSION="sdk-1.38.15-64bit"
 
@@ -23,10 +23,10 @@ cd $FO_BUILD_DEST
 mkdir -p web
 cd web
 mkdir -p "./Binaries/Client/Web" && rm -rf "./Binaries/Client/Web/*"
-cp -r "$SOURCE_FULL_PATH/BuildScripts/web/." "./Binaries/Client/Web"
+cp -r "$ROOT_FULL_PATH/BuildScripts/web/." "./Binaries/Client/Web"
 
 mkdir -p emsdk
-cp -r "$SOURCE_FULL_PATH/BuildScripts/emsdk" "./"
+cp -r "$ROOT_FULL_PATH/BuildScripts/emsdk" "./"
 cd emsdk
 chmod +x ./emsdk
 ./emsdk update
@@ -38,12 +38,12 @@ emcc -v
 
 mkdir -p release
 cd release
-cmake -G "Unix Makefiles" -C "$SOURCE_FULL_PATH/BuildScripts/web.cache.cmake" "$SOURCE_FULL_PATH/Source"
+cmake -G "Unix Makefiles" -C "$ROOT_FULL_PATH/BuildScripts/web.cache.cmake" "$ROOT_FULL_PATH/Source"
 make -j4
 cd ../
 
 mkdir -p debug
 cd debug
-cmake -G "Unix Makefiles" -C "$SOURCE_FULL_PATH/BuildScripts/web.cache.cmake" -DFO_DEBUG=ON "$SOURCE_FULL_PATH/Source"
+cmake -G "Unix Makefiles" -C "$ROOT_FULL_PATH/BuildScripts/web.cache.cmake" -DFO_DEBUG=ON "$ROOT_FULL_PATH/Source"
 make -j4
 cd ../

--- a/BuildScripts/windows.bat
+++ b/BuildScripts/windows.bat
@@ -1,10 +1,10 @@
 ECHO ON
 
-IF [%FO_SOURCE%] == [] ECHO FO_SOURCE is empty & EXIT /B 1
+IF [%FO_ROOT%] == [] ECHO FO_ROOT is empty & EXIT /B 1
 IF [%FO_BUILD_DEST%] == [] ECHO FO_BUILD_DEST is empty & EXIT /B 1
 
-PUSHD %CD%\%FO_SOURCE%
-SET SOURCE_FULL_PATH=%CD%
+PUSHD %CD%\%FO_ROOT%
+SET ROOT_FULL_PATH=%CD%
 POPD
 
 MKDIR %FO_BUILD_DEST%
@@ -16,12 +16,12 @@ IF EXIST windows\ASCompiler RD windows\ASCompiler /S /Q
 
 MKDIR windows\x86
 PUSHD windows\x86
-cmake -G "Visual Studio 15 2017" "%SOURCE_FULL_PATH%\Source"
+cmake -G "Visual Studio 15 2017" "%ROOT_FULL_PATH%\Source"
 POPD
 
 MKDIR windows\x64
 PUSHD windows\x64
-cmake -G "Visual Studio 15 2017 Win64" "%SOURCE_FULL_PATH%\Source"
+cmake -G "Visual Studio 15 2017 Win64" "%ROOT_FULL_PATH%\Source"
 POPD
 
 cmake --build windows\x64 --config RelWithDebInfo --target FOnlineServer

--- a/BuildScripts/windows.bat
+++ b/BuildScripts/windows.bat
@@ -1,7 +1,7 @@
 ECHO ON
 
-IF [%FO_ROOT%] == [] ECHO FO_ROOT is empty & EXIT /B 1
-IF [%FO_BUILD_DEST%] == [] ECHO FO_BUILD_DEST is empty & EXIT /B 1
+IF [%FO_ROOT%] == [] ECHO FO_ROOT variable is not set & EXIT /B 1
+IF [%FO_BUILD_DEST%] == [] ECHO FO_BUILD_DEST variable is not set & EXIT /B 1
 
 PUSHD %CD%\%FO_ROOT%
 SET ROOT_FULL_PATH=%CD%

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   environment {
     FO_BUILD_DEST = 'Build'
-    FO_SOURCE = '.'
+    FO_ROOT = '.'
     FO_INSTALL_PACKAGES = 0
   }
   options {


### PR DESCRIPTION
- Changes \*SOURCE\* vars names to \*ROOT\*; \*SOURCE* is a bit misleading with Source/ directory around
- Slightly increases error messages in build scripts
- Adds entries to .gitattributes to keep line endings in scripts
