### PR TITLE
Server ping response changes

### DIFF
--- a/Source/Server.cpp
+++ b/Source/Server.cpp
@@ -405,16 +405,16 @@ void FOServer::Process( Client* cl )
             {
             case 0xFFFFFFFF:
             {
-                // at least 16 bytes should be sent for backward compatibility,
+                // At least 16 bytes should be sent for backward compatibility,
                 // even if answer data will change its meaning
                 BOUT_BEGIN( cl );
                 cl->Connection->DisableCompression();
-                cl->Connection->Bout << (uint)Statistics.CurOnline - 1;
-                cl->Connection->Bout << (uint)Statistics.Uptime;
-                cl->Connection->Bout << (uint)0;
-                cl->Connection->Bout << (uchar)0;
-                cl->Connection->Bout << (uchar)0xF0;
-                cl->Connection->Bout << (ushort)FONLINE_VERSION;
+                cl->Connection->Bout << (uint) Statistics.CurOnline - 1;
+                cl->Connection->Bout << (uint) Statistics.Uptime;
+                cl->Connection->Bout << (uint) 0;
+                cl->Connection->Bout << (uchar) 0;
+                cl->Connection->Bout << (uchar) 0xF0;
+                cl->Connection->Bout << (ushort) FONLINE_VERSION;
                 BOUT_END( cl );
                 cl->Disconnect();
                 BIN_END( cl );

--- a/Source/Server.cpp
+++ b/Source/Server.cpp
@@ -405,16 +405,21 @@ void FOServer::Process( Client* cl )
             {
             case 0xFFFFFFFF:
             {
-                uint answer[ 4 ] = { CrMngr.PlayersInGame(), Statistics.Uptime, 0, 0 };
+                // at least 16 bytes should be sent for backward compatibility,
+                // even if answer data will change its meaning
                 BOUT_BEGIN( cl );
                 cl->Connection->DisableCompression();
-                cl->Connection->Bout.Push( answer, sizeof( answer ) );
-
+                cl->Connection->Bout << (uint)Statistics.CurOnline - 1;
+                cl->Connection->Bout << (uint)Statistics.Uptime;
+                cl->Connection->Bout << (uint)0;
+                cl->Connection->Bout << (uchar)0;
+                cl->Connection->Bout << (uchar)0xF0;
+                cl->Connection->Bout << (ushort)FONLINE_VERSION;
                 BOUT_END( cl );
                 cl->Disconnect();
-            }
                 BIN_END( cl );
                 break;
+            }
             case NETMSG_PING:
                 Process_Ping( cl );
                 BIN_END( cl );


### PR DESCRIPTION
- responds with number of connections instead of players
  servers often use NoLogout maps for weird stuff and it's not unusual there are dozens of offline chars, which gives a wrong "feeling" about server population at given moment
- adds engine id/version
  opens a way to expand ping response in future: smart status checkers can check which engine/version they deal with and apply different response handling logic