### PR TITLE
Fix msg_len of NETMSG_MSG_LEX

### DIFF
--- a/Source/Server/Critter.cpp
+++ b/Source/Server/Critter.cpp
@@ -1664,7 +1664,7 @@ void Client::Send_TextMsgLex(Critter* from_cr, uint num_str, uchar how_say, usho
     }
 
     const auto from_id = (from_cr != nullptr ? from_cr->GetId() : 0u);
-    const uint msg_len = NETMSG_MSG_SIZE + sizeof(lex_len) + lex_len;
+    const uint msg_len = sizeof(msg_len) + NETMSG_MSG_SIZE + sizeof(lex_len) + lex_len;
 
     CLIENT_OUTPUT_BEGIN(this);
     Connection->Bout << NETMSG_MSG_LEX;
@@ -1693,7 +1693,7 @@ void Client::Send_TextMsgLex(uint from_id, uint num_str, uchar how_say, ushort n
         return;
     }
 
-    const uint msg_len = NETMSG_MSG_SIZE + sizeof(lex_len) + lex_len;
+    const uint msg_len = sizeof(msg_len) + NETMSG_MSG_SIZE + sizeof(lex_len) + lex_len;
 
     CLIENT_OUTPUT_BEGIN(this);
     Connection->Bout << NETMSG_MSG_LEX;


### PR DESCRIPTION
`NETMSG_MSG` has const length, so `NETMSG_MSG_SIZE` has header, but doesn't have `msg_len`.
`NETMSG_MSG_LEX` has dynamic length but uses `NETMSG_MSG_SIZE` to calculate its own `msg_len`.
This makes `msg_len` of `NETMSG_MSG_LEX` to be 4 bytes smaller than it should.
This bug was introduced in 9f70b0a67b573021e814c3fb9b5a06e0a1c6cee1
`msg_len` was also incorrect for NETMSG_SEND_BARTER (it was missing `npc_id` size), but now there's no such message.

<a href="https://gitpod.io/#https://github.com/cvet/fonline/pull/67"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

