### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/ThirdParty/LibreSSL/crypto/x509/x509_utl.c
+++ b/ThirdParty/LibreSSL/crypto/x509/x509_utl.c
@@ -729,17 +729,26 @@ append_ia5(STACK_OF(OPENSSL_STRING) **sk, ASN1_IA5STRING *email)
 	/* First some sanity checks */
 	if (email->type != V_ASN1_IA5STRING)
 		return 1;
-	if (!email->data || !email->length)
+	if (email->data == NULL || email->length == 0)
+        return 1;
+    if (memchr(email->data, 0, email->length) != NULL)
 		return 1;
 	if (!*sk)
 		*sk = sk_OPENSSL_STRING_new(sk_strcmp);
 	if (!*sk)
 		return 0;
 	/* Don't add duplicates */
-	if (sk_OPENSSL_STRING_find(*sk, (char *)email->data) != -1)
+
+	emtmp = OPENSSL_strndup((char *)email->data, email->length);
+    if (emtmp == NULL)
+        return 0;
+
+	 if (sk_OPENSSL_STRING_find(*sk, emtmp) != -1) {
+        OPENSSL_free(emtmp);
 		return 1;
-	emtmp = strdup((char *)email->data);
-	if (!emtmp || !sk_OPENSSL_STRING_push(*sk, emtmp)) {
+	}
+    if (!sk_OPENSSL_STRING_push(*sk, emtmp)) {
+        OPENSSL_free(emtmp); /* free on push failure */
 		X509_email_free(*sk);
 		*sk = NULL;
 		return 0;


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in ThirdParty/LibreSSL/crypto/x509/x509_utl.c which was cloned from openssl/openssl but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2021-3712.

### Proposed Fix
Apply the same patch as the one in openssl/openssl to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2021-3712
https://github.com/openssl/openssl/commit/bb4d2ed4091408404e18b3326e3df67848ef63d0