### PR TITLE
64 bit hashes

### DIFF
--- a/Source/Client/3dStuff.cpp
+++ b/Source/Client/3dStuff.cpp
@@ -36,6 +36,7 @@
 #if FO_ENABLE_3D
 
 #include "Application.h"
+#include "EngineBase.h"
 #include "Settings.h"
 
 FO_BEGIN_NAMESPACE
@@ -2235,6 +2236,21 @@ ModelInformation::ModelInformation(ModelManager& model_mngr) :
     _viewSize.height = _modelMngr->_settings->DefaultModelViewHeight != 0 ? _modelMngr->_settings->DefaultModelViewHeight : _viewSize.height / 2;
 }
 
+auto ModelInformation::ParseInt32Value(string_view value, bool* failed) const -> int32
+{
+    FO_STACK_TRACE_ENTRY();
+
+    if (strvex(value).is_explicit_bool()) {
+        return strvex(value).to_bool() ? 1 : 0;
+    }
+    if (strvex(value).is_number()) {
+        return numeric_cast<int32>(strvex(value).to_int64());
+    }
+
+    const auto enum_value = _modelMngr->_nameResolver->ResolveEnumValue(value, failed);
+    return enum_value;
+}
+
 auto ModelInformation::Load(string_view name) -> bool
 {
     FO_STACK_TRACE_ENTRY();
@@ -2366,10 +2382,10 @@ auto ModelInformation::Load(string_view name) -> bool
                 *istr >> buf;
 
                 if (token == "Layer") {
-                    layer = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                    layer = ParseInt32Value(buf, &convert_value_fail);
                 }
                 else {
-                    layer_val = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                    layer_val = ParseInt32Value(buf, &convert_value_fail);
                 }
 
                 link = &dummy_link;
@@ -2446,7 +2462,7 @@ auto ModelInformation::Load(string_view name) -> bool
 
                     for (auto& cut_layer_name : cur_layer_names) {
                         if (cut_layer_name != "All") {
-                            const auto cut_layer = _modelMngr->_nameResolver->ResolveGenericValue(cut_layer_name, &convert_value_fail);
+                            const auto cut_layer = ParseInt32Value(cut_layer_name, &convert_value_fail);
                             cut->Layers.emplace_back(cut_layer);
                         }
                         else {
@@ -2663,7 +2679,7 @@ auto ModelInformation::Load(string_view name) -> bool
                 const auto disabled_layers = strex(buf).split('-');
 
                 for (const auto& disabled_layer_name : disabled_layers) {
-                    const auto disabled_layer = _modelMngr->_nameResolver->ResolveGenericValue(disabled_layer_name, &convert_value_fail);
+                    const auto disabled_layer = ParseInt32Value(disabled_layer_name, &convert_value_fail);
 
                     if (disabled_layer >= 0 && disabled_layer < const_numeric_cast<int32>(MODEL_LAYERS_COUNT)) {
                         link->DisabledLayer.emplace_back(disabled_layer);
@@ -2686,7 +2702,7 @@ auto ModelInformation::Load(string_view name) -> bool
             }
             else if (token == "Texture") {
                 *istr >> buf;
-                auto index = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                auto index = ParseInt32Value(buf, &convert_value_fail);
 
                 *istr >> buf;
 
@@ -2701,9 +2717,9 @@ auto ModelInformation::Load(string_view name) -> bool
             }
             else if (token == "Anim") {
                 *istr >> buf;
-                const auto ind1 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                const auto ind1 = ParseInt32Value(buf, &convert_value_fail);
                 *istr >> buf;
-                const auto ind2 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                const auto ind2 = ParseInt32Value(buf, &convert_value_fail);
 
                 string a1;
                 string a2;
@@ -2712,9 +2728,9 @@ auto ModelInformation::Load(string_view name) -> bool
             }
             else if (token == "AnimSpeed") {
                 *istr >> buf;
-                const auto ind1 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                const auto ind1 = ParseInt32Value(buf, &convert_value_fail);
                 *istr >> buf;
-                const auto ind2 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                const auto ind2 = ParseInt32Value(buf, &convert_value_fail);
 
                 float32 valuef = 0.0f;
                 *istr >> valuef;
@@ -2722,14 +2738,14 @@ auto ModelInformation::Load(string_view name) -> bool
             }
             else if (token == "AnimLayerValue") {
                 *istr >> buf;
-                const auto ind1 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                const auto ind1 = ParseInt32Value(buf, &convert_value_fail);
                 *istr >> buf;
-                const auto ind2 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                const auto ind2 = ParseInt32Value(buf, &convert_value_fail);
 
                 *istr >> buf;
-                const auto anim_layer = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                const auto anim_layer = ParseInt32Value(buf, &convert_value_fail);
                 *istr >> buf;
-                const auto anim_layer_value = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                const auto anim_layer_value = ParseInt32Value(buf, &convert_value_fail);
 
                 const auto index = std::make_pair(static_cast<CritterStateAnim>(ind1), static_cast<CritterActionAnim>(ind2));
 
@@ -2747,9 +2763,9 @@ auto ModelInformation::Load(string_view name) -> bool
                 auto ind1 = 0;
                 auto ind2 = 0;
                 *istr >> buf;
-                ind1 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                ind1 = ParseInt32Value(buf, &convert_value_fail);
                 *istr >> buf;
-                ind2 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                ind2 = ParseInt32Value(buf, &convert_value_fail);
 
                 _stateAnimEquals.emplace(static_cast<CritterStateAnim>(ind1), static_cast<CritterStateAnim>(ind2));
             }
@@ -2757,9 +2773,9 @@ auto ModelInformation::Load(string_view name) -> bool
                 auto ind1 = 0;
                 auto ind2 = 0;
                 *istr >> buf;
-                ind1 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                ind1 = ParseInt32Value(buf, &convert_value_fail);
                 *istr >> buf;
-                ind2 = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                ind2 = ParseInt32Value(buf, &convert_value_fail);
 
                 _actionAnimEquals.emplace(static_cast<CritterActionAnim>(ind1), static_cast<CritterActionAnim>(ind2));
             }
@@ -2768,15 +2784,15 @@ auto ModelInformation::Load(string_view name) -> bool
             }
             else if (token == "DrawSize") {
                 *istr >> buf;
-                _drawSize.width = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                _drawSize.width = ParseInt32Value(buf, &convert_value_fail);
                 *istr >> buf;
-                _drawSize.height = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                _drawSize.height = ParseInt32Value(buf, &convert_value_fail);
             }
             else if (token == "ViewSize") {
                 *istr >> buf;
-                _viewSize.width = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                _viewSize.width = ParseInt32Value(buf, &convert_value_fail);
                 *istr >> buf;
-                _viewSize.height = _modelMngr->_nameResolver->ResolveGenericValue(buf, &convert_value_fail);
+                _viewSize.height = ParseInt32Value(buf, &convert_value_fail);
             }
             else if (token == "DisableAnimationInterpolation") {
                 disable_animation_interpolation = true;

--- a/Source/Client/3dStuff.h
+++ b/Source/Client/3dStuff.h
@@ -400,6 +400,7 @@ public:
 private:
     [[nodiscard]] auto GetAnimationIndex(CritterStateAnim& state_anim, CritterActionAnim& action_anim, float32* speed) -> int32;
     [[nodiscard]] auto GetAnimationIndexEx(CritterStateAnim state_anim, CritterActionAnim action_anim, float32* speed) const -> int32;
+    [[nodiscard]] auto ParseInt32Value(string_view value, bool* failed) const -> int32;
     [[nodiscard]] auto CreateCutShape(MeshData* mesh) const -> ModelCutData::Shape;
 
     [[nodiscard]] auto Load(string_view name) -> bool;

--- a/Source/Client/Client.cpp
+++ b/Source/Client/Client.cpp
@@ -86,8 +86,8 @@ ClientEngine::ClientEngine(GlobalSettings& settings, FileSystem&& resources, IAp
 
     InitSubsystems(this);
 
-    _curLang = LanguagePack {Settings.Language, *this};
-    _curLang.LoadFromResources(Resources);
+    _curLang = TextPack {Hashes};
+    _curLang.LoadFromResources(Resources, Settings.Language);
 
     // Modules initialization
     InitClientEngine(this);
@@ -2276,8 +2276,8 @@ void ClientEngine::ChangeLanguage(string_view lang_name)
 {
     FO_STACK_TRACE_ENTRY();
 
-    auto lang_pack = LanguagePack {lang_name, *this};
-    lang_pack.LoadFromResources(Resources);
+    auto lang_pack = TextPack {Hashes};
+    lang_pack.LoadFromResources(Resources, lang_name);
 
     _curLang = std::move(lang_pack);
     Settings.Language = lang_name;

--- a/Source/Client/Client.h
+++ b/Source/Client/Client.h
@@ -129,7 +129,7 @@ public:
     [[nodiscard]] auto GetGlobalMapCritter(ident_t cr_id) -> CritterView*;
     [[nodiscard]] auto GetGlobalMapCritters() const noexcept -> const vector<refcount_ptr<CritterView>>& { return _globalMapCritters; }
     [[nodiscard]] auto GetGlobalMapCritters() noexcept -> vector<refcount_ptr<CritterView>>& { return _globalMapCritters; }
-    [[nodiscard]] auto GetCurLang() const noexcept -> const LanguagePack& { return _curLang; }
+    [[nodiscard]] auto GetCurLang() const noexcept -> const TextPack& { return _curLang; }
     [[nodiscard]] auto IsVideoPlaying() const noexcept -> bool { return !!_video || !_videoQueue.empty(); }
     [[nodiscard]] auto GetCurPlayer() noexcept -> PlayerView* { return _curPlayer.get(); }
     [[nodiscard]] auto GetCurLocation() noexcept -> LocationView* { return _curLocation.get(); }
@@ -357,7 +357,7 @@ protected:
     ClientConnection _conn;
     bool _connectionRequest {};
     EventUnsubscriber _eventUnsubscriber {};
-    LanguagePack _curLang {};
+    TextPack _curLang {Hashes};
 
     unordered_map<ident_t, raw_ptr<ClientEntity>> _allEntities {};
     vector<refcount_ptr<CritterView>> _globalMapCritters {};

--- a/Source/Client/ResourceManager.cpp
+++ b/Source/Client/ResourceManager.cpp
@@ -133,20 +133,20 @@ void ResourceManager::CleanupCritterFrames()
     _critterFrames.clear();
 }
 
-static auto AnimMapId(hstring model_name, CritterStateAnim state_anim, CritterActionAnim action_anim) -> uint32
+static auto AnimMapId(hstring model_name, CritterStateAnim state_anim, CritterActionAnim action_anim) -> hstring::hash_t
 {
     FO_STACK_TRACE_ENTRY();
 
-    const uint32 dw[4] = {model_name.as_uint32(), static_cast<uint32>(state_anim), static_cast<uint32>(action_anim), 1};
-    return Hashing::MurmurHash2(dw, sizeof(dw));
+    const hstring::hash_t parts[4] = {model_name.as_hash(), static_cast<hstring::hash_t>(state_anim), static_cast<hstring::hash_t>(action_anim), static_cast<hstring::hash_t>(1)};
+    return hashing_ex::hash(parts, sizeof(parts));
 }
 
-static auto FalloutAnimMapId(hstring model_name, uint32 state_anim, uint32 action_anim) -> uint32
+static auto FalloutAnimMapId(hstring model_name, uint32 state_anim, uint32 action_anim) -> hstring::hash_t
 {
     FO_STACK_TRACE_ENTRY();
 
-    const uint32 dw[4] = {model_name.as_uint32(), numeric_cast<uint32>(state_anim), numeric_cast<uint32>(action_anim), numeric_cast<uint32>(0xFFFFFFFF)};
-    return Hashing::MurmurHash2(dw, sizeof(dw));
+    const hstring::hash_t parts[4] = {model_name.as_hash(), numeric_cast<hstring::hash_t>(state_anim), numeric_cast<hstring::hash_t>(action_anim), std::numeric_limits<hstring::hash_t>::max()};
+    return hashing_ex::hash(parts, sizeof(parts));
 }
 
 auto ResourceManager::GetCritterAnimFrames(hstring model_name, CritterStateAnim state_anim, CritterActionAnim action_anim, uint8 dir) -> const SpriteSheet*

--- a/Source/Client/ResourceManager.h
+++ b/Source/Client/ResourceManager.h
@@ -76,7 +76,7 @@ private:
     raw_ptr<FileSystem> _resources;
     raw_ptr<SpriteManager> _sprMngr;
     raw_ptr<AnimationResolver> _animNameResolver;
-    unordered_map<uint32, shared_ptr<SpriteSheet>> _critterFrames {};
+    unordered_map<hstring::hash_t, shared_ptr<SpriteSheet>> _critterFrames {};
     shared_ptr<SpriteSheet> _critterDummyAnimFrames {};
     shared_ptr<Sprite> _itemHexDummyAnim {};
     map<string, string> _soundNames {};

--- a/Source/Common/Common.h
+++ b/Source/Common/Common.h
@@ -57,7 +57,7 @@ extern bool IsTestingInProgress;
 #define FO_DEFERRED // Lambda annotation
 
 ///@ ExportValueType ident ident_t Layout = int64-value
-using ident_t = strong_type<int64, struct ident_t_, strong_type_bool_test_tag>;
+using ident_t = strong_type<int64, struct ident_t_, strong_type_bool_test_tag, strong_type_sortings_tag>;
 static_assert(some_strong_type<ident_t>);
 
 // Custom any as string
@@ -581,6 +581,10 @@ void VisitBaseTypePrimitive(void* p, const BaseTypeDesc& type, const Fn& fn)
             return;
         }
     }
+    else if (type.IsHashedString) {
+        fn(*cast_from_void<hstring*>(p));
+        return;
+    }
     else if (type.IsEnum) {
         VisitBaseTypePrimitive(p, *type.EnumUnderlyingType, fn);
         return;
@@ -659,6 +663,10 @@ void VisitBaseTypePrimitive(const void* p, const BaseTypeDesc& type, const Fn& f
             return;
         }
     }
+    else if (type.IsHashedString) {
+        fn(*cast_from_void<const hstring*>(p));
+        return;
+    }
     else if (type.IsEnum) {
         VisitBaseTypePrimitive(p, *type.EnumUnderlyingType, fn);
         return;
@@ -727,6 +735,9 @@ decltype(auto) VisitBaseTypePrimitive(const void* a, const void* b, const BaseTy
             return fn(*cast_from_void<const float64*>(a), *cast_from_void<const float64*>(b));
         }
     }
+    else if (type.IsHashedString) {
+        return fn(*cast_from_void<const hstring*>(a), *cast_from_void<const hstring*>(b));
+    }
     else if (type.IsEnum) {
         return VisitBaseTypePrimitive(a, b, *type.EnumUnderlyingType, std::forward<Fn>(fn));
     }
@@ -751,7 +762,6 @@ public:
     [[nodiscard]] virtual auto ResolveEnumValue(string_view enum_value_name, bool* failed = nullptr) const -> int32 = 0;
     [[nodiscard]] virtual auto ResolveEnumValue(string_view enum_name, string_view value_name, bool* failed = nullptr) const -> int32 = 0;
     [[nodiscard]] virtual auto ResolveEnumValueName(string_view enum_name, int32 value, bool* failed = nullptr) const -> const string& = 0;
-    [[nodiscard]] virtual auto ResolveGenericValue(string_view str, bool* failed = nullptr) const -> int32 = 0;
     [[nodiscard]] virtual auto CheckMigrationRule(hstring rule_name, hstring extra_info, hstring target) const noexcept -> optional<hstring> = 0;
     [[nodiscard]] virtual auto GetProtoEntity(hstring type_name, hstring proto_id) const noexcept -> const ProtoEntity* = 0;
     virtual ~NameResolver() = default;

--- a/Source/Common/ConfigFile.cpp
+++ b/Source/Common/ConfigFile.cpp
@@ -48,9 +48,8 @@ ConfigFile::~ConfigFile() = default;
 ConfigFile::ConfigFile(ConfigFile&&) noexcept = default;
 auto ConfigFile::operator=(ConfigFile&&) noexcept -> ConfigFile& = default;
 
-ConfigFile::ConfigFile(string_view name_hint, string str, HashResolver* hash_resolver, ConfigFileOption options) :
+ConfigFile::ConfigFile(string_view name_hint, string str, ConfigFileOption options) :
     _fileNameHint {name_hint},
-    _hashResolver {hash_resolver},
     _options {options},
     _data {unique_ptr<Data> {SafeAlloc::MakeRaw<Data>()}}
 {
@@ -166,76 +165,47 @@ ConfigFile::ConfigFile(string_view name_hint, string str, HashResolver* hash_res
                 section_content.append(line.data(), line.size()).append("\n");
             }
 
-            // Text format {}{}{}
-            if (line.front() == '{') {
-                uint32 num = 0;
-                size_t offset = 0;
+            string_view raw_key;
+            string_view raw_value;
+            bool append_value = false;
 
-                for (int32 i = 0; i < 3; i++) {
-                    const size_t first = line.find('{', offset);
-                    const size_t last = line.find('}', first);
-
-                    if (first == string_view::npos || last == string_view::npos) {
-                        break;
-                    }
-
-                    const string_view str2 = line.substr(first + 1, last - first - 1);
-                    offset = last + 1;
-
-                    if (i == 0 && num == 0) {
-                        num = strvex(str2).is_number() ? numeric_cast<uint32>(strvex(str2).to_int64()) : _hashResolver->ToHashedString(str2).as_int32();
-                    }
-                    else if (i == 1 && num != 0) {
-                        num += !str2.empty() ? (strvex(str2).is_number() ? numeric_cast<uint32>(strvex(str2).to_int64()) : _hashResolver->ToHashedString(str2).as_int32()) : 0;
-                    }
-                    else if (i == 2 && num != 0) {
-                        (*cur_section)[StoreOwnedString(strex("{}", num).str())] = line_stable ? str2 : StoreOwnedString(str2);
-                    }
-                }
+            if (!ParseConfigKeyValueLine(line, raw_key, raw_value, append_value)) {
+                continue;
             }
-            else {
-                string_view raw_key;
-                string_view raw_value;
-                bool append_value = false;
 
-                if (!ParseConfigKeyValueLine(line, raw_key, raw_value, append_value)) {
-                    continue;
-                }
+            key.clear();
+            value.clear();
+            const bool entry_changed = ConfigEntryParseHook(_fileNameHint, section_name_for_hook, raw_key, raw_value, key, value);
 
-                key.clear();
-                value.clear();
-                const bool entry_changed = ConfigEntryParseHook(_fileNameHint, section_name_for_hook, raw_key, raw_value, key, value);
+            const string_view entry_key = entry_changed ? string_view {key} : raw_key;
+            const string_view entry_value = entry_changed ? string_view {value} : raw_value;
 
-                const string_view entry_key = entry_changed ? string_view {key} : raw_key;
-                const string_view entry_value = entry_changed ? string_view {value} : raw_value;
+            if (entry_key.empty()) {
+                continue;
+            }
 
-                if (entry_key.empty()) {
-                    continue;
-                }
+            const string_view stored_key = line_stable && !entry_changed ? raw_key : StoreOwnedString(entry_key);
+            const string_view stored_value = line_stable && !entry_changed ? raw_value : StoreOwnedString(entry_value);
 
-                const string_view stored_key = line_stable && !entry_changed ? raw_key : StoreOwnedString(entry_key);
-                const string_view stored_value = line_stable && !entry_changed ? raw_value : StoreOwnedString(entry_value);
+            if (append_value) {
+                const auto existing_it = cur_section->find(stored_key);
 
-                if (append_value) {
-                    const auto existing_it = cur_section->find(stored_key);
-
-                    if (existing_it != cur_section->end()) {
-                        if (!stored_value.empty()) {
-                            string merged_value;
-                            merged_value.reserve(existing_it->second.size() + 1 + stored_value.size());
-                            merged_value.append(existing_it->second);
-                            merged_value.push_back(' ');
-                            merged_value.append(stored_value);
-                            existing_it->second = StoreOwnedString(std::move(merged_value));
-                        }
-                    }
-                    else {
-                        (*cur_section)[stored_key] = stored_value;
+                if (existing_it != cur_section->end()) {
+                    if (!stored_value.empty()) {
+                        string merged_value;
+                        merged_value.reserve(existing_it->second.size() + 1 + stored_value.size());
+                        merged_value.append(existing_it->second);
+                        merged_value.push_back(' ');
+                        merged_value.append(stored_value);
+                        existing_it->second = StoreOwnedString(std::move(merged_value));
                     }
                 }
                 else {
                     (*cur_section)[stored_key] = stored_value;
                 }
+            }
+            else {
+                (*cur_section)[stored_key] = stored_value;
             }
         }
     }

--- a/Source/Common/ConfigFile.h
+++ b/Source/Common/ConfigFile.h
@@ -47,7 +47,7 @@ enum class ConfigFileOption : uint8
 class ConfigFile final
 {
 public:
-    explicit ConfigFile(string_view name_hint, string str, HashResolver* hash_resolver = nullptr, ConfigFileOption options = ConfigFileOption::None);
+    explicit ConfigFile(string_view name_hint, string str, ConfigFileOption options = ConfigFileOption::None);
     ConfigFile(const ConfigFile&) = delete;
     ConfigFile(ConfigFile&&) noexcept;
     auto operator=(const ConfigFile&) = delete;
@@ -78,7 +78,6 @@ private:
     auto StoreOwnedString(string&& value) -> string_view;
 
     string _fileNameHint;
-    raw_ptr<HashResolver> _hashResolver;
     ConfigFileOption _options;
     unique_ptr<Data> _data;
     multimap<string_view, map<string_view, string_view>> _sectionKeyValues {};

--- a/Source/Common/EngineBase.cpp
+++ b/Source/Common/EngineBase.cpp
@@ -348,7 +348,7 @@ void EngineMetadata::RegisterValueTypeLayout(string_view name, const vector<pair
         auto& field = layout_desc.Fields.emplace_back();
         field.Name = field_name;
         field.Type = GetBaseType(field_type);
-        FO_RUNTIME_ASSERT(field.Type.IsPrimitive || field.Type.IsEnum || field.Type.IsSimpleStruct);
+        FO_RUNTIME_ASSERT(field.Type.IsPrimitive || field.Type.IsEnum || field.Type.IsSimpleStruct || field.Type.IsHashedString);
         FO_RUNTIME_ASSERT(field.Type.Size != 0);
         FO_RUNTIME_ASSERT_STR(offset % field.Type.Size == 0, strex("{}::{} layout data is not aligned", name, field.Name));
         field.Offset = offset;
@@ -960,48 +960,6 @@ auto EngineMetadata::ResolveEnumValueName(string_view enum_name, int32 value, bo
     }
 
     return value_it->second;
-}
-
-auto EngineMetadata::ResolveGenericValue(string_view str, bool* failed) const -> int32
-{
-    FO_STACK_TRACE_ENTRY();
-
-    if (str.empty()) {
-        return 0;
-    }
-    if (str[0] == '"') {
-        return 0;
-    }
-
-    if (str[0] == '@') {
-        return Hashes.ToHashedString(str.substr(1)).as_int32();
-    }
-    else if (str.starts_with("Content::")) {
-        return Hashes.ToHashedString(str.substr(str.rfind(':') + 1)).as_int32();
-    }
-    else if (strex(str).is_number()) {
-        return strex(str).to_int32();
-    }
-    else if (strex(str).compare_ignore_case("true")) {
-        return 1;
-    }
-    else if (strex(str).compare_ignore_case("false")) {
-        return 0;
-    }
-
-    bool enum_failed = false;
-    const auto enum_value = ResolveEnumValue(str, &enum_failed);
-
-    if (enum_failed) {
-        WriteLog("Failed to resolve generic value: '{}'", str);
-
-        if (failed != nullptr) {
-            *failed = true;
-            return 0;
-        }
-    }
-
-    return enum_value;
 }
 
 auto EngineMetadata::GetGameSetting(string_view name) const -> const BaseTypeDesc&

--- a/Source/Common/EngineBase.h
+++ b/Source/Common/EngineBase.h
@@ -72,7 +72,6 @@ public:
     [[nodiscard]] auto ResolveEnumValue(string_view enum_value_name, bool* failed = nullptr) const -> int32 override;
     [[nodiscard]] auto ResolveEnumValue(string_view enum_name, string_view value_name, bool* failed = nullptr) const -> int32 override;
     [[nodiscard]] auto ResolveEnumValueName(string_view enum_name, int32 value, bool* failed = nullptr) const -> const string& override;
-    [[nodiscard]] auto ResolveGenericValue(string_view str, bool* failed = nullptr) const -> int32 override;
     [[nodiscard]] auto IsValidEntityType(hstring type_name) const noexcept -> bool;
     [[nodiscard]] auto IsValidEntityType(string_view type_name) const noexcept -> bool;
     [[nodiscard]] auto GetEntityType(hstring type_name) const -> const EntityTypeDesc&;
@@ -124,7 +123,7 @@ public:
     void RegisterProto(hstring type_name, const refcount_ptr<ProtoEntity>& proto);
     void FinalizeRegistration();
 
-    mutable HashStorage Hashes;
+    mutable HashStorage Hashes {};
 
 private:
     auto RegisterBaseType(string_view type_str) -> BaseTypeDesc&;

--- a/Source/Common/MapLoader.cpp
+++ b/Source/Common/MapLoader.cpp
@@ -51,7 +51,7 @@ void MapLoader::Load(string_view name, const string& buf, const EngineMetadata& 
     }
 
     // Header
-    ConfigFile map_data(strex("{}.fomap", name), buf, &hash_resolver);
+    ConfigFile map_data(strex("{}.fomap", name), buf);
 
     if (!map_data.HasSection("ProtoMap")) {
         throw MapLoaderException("Invalid map format", name);

--- a/Source/Common/TextPack.cpp
+++ b/Source/Common/TextPack.cpp
@@ -36,26 +36,112 @@
 
 FO_BEGIN_NAMESPACE
 
-void TextPack::AddStr(TextPackKey num, string_view str)
+static auto ExtractBraceToken(string& line, size_t& offset, string& token, bool allow_multiline, istringstream* sstr) -> bool
 {
     FO_STACK_TRACE_ENTRY();
 
-    _strData.emplace(num, string(str));
+    const auto first = line.find('{', offset);
+
+    if (first == string::npos) {
+        return false;
+    }
+
+    auto last = line.find('}', first);
+
+    if (last == string::npos && allow_multiline && sstr != nullptr) {
+        string additional_line;
+
+        while (last == string::npos && std::getline(*sstr, additional_line, '\n')) {
+            line += "\n" + additional_line;
+            last = line.find('}', first);
+        }
+    }
+
+    if (last == string::npos) {
+        return false;
+    }
+
+    token = line.substr(first + 1, last - first - 1);
+    offset = last + 1;
+    return true;
 }
 
-void TextPack::AddStr(TextPackKey num, string&& str)
+auto TextPackKey::FromParts(HashResolver& hash_resolver, string_view collection, string_view key1, string_view key2, string_view key3) -> TextPackKey
 {
     FO_STACK_TRACE_ENTRY();
 
-    _strData.emplace(num, std::move(str));
+    const auto hcollection = hash_resolver.ToHashedString(collection);
+    const auto hkey1 = hash_resolver.ToHashedString(key1);
+    const auto hkey2 = hash_resolver.ToHashedString(key2);
+    const auto hkey3 = hash_resolver.ToHashedString(key3);
+    return TextPackKey {TextPackName {hcollection}, hkey1, hkey2, hkey3};
 }
 
-auto TextPack::GetStr(TextPackKey num) const -> const string&
+auto TextPackKey::FromPack(HashResolver& hash_resolver, string_view collection, string_view key1, string_view key2, string_view key3) -> TextPackKey
 {
     FO_STACK_TRACE_ENTRY();
 
-    const size_t str_count = _strData.count(num);
-    auto it = _strData.find(num);
+    return FromParts(hash_resolver, collection, key1, key2, key3);
+}
+
+auto TextPackKey::Parse(HashResolver& hash_resolver, string_view str, TextPackKey& result) -> bool
+{
+    FO_STACK_TRACE_ENTRY();
+
+    string source {str};
+    size_t offset = 0;
+    string tokens[4];
+
+    for (auto& token : tokens) {
+        if (!ExtractBraceToken(source, offset, token, false, nullptr)) {
+            return false;
+        }
+    }
+
+    result = FromParts(hash_resolver, tokens[0], tokens[1], tokens[2], tokens[3]);
+    return true;
+}
+
+TextPack::TextPack(HashResolver& hash_resolver) :
+    _hashResolver {&hash_resolver}
+{
+    FO_STACK_TRACE_ENTRY();
+}
+
+auto TextPack::GetText(TextPackKey key) const -> const string&
+{
+    FO_STACK_TRACE_ENTRY();
+
+    return GetText(key, 0);
+}
+
+auto TextPack::GetText(TextPackKey key, size_t skip) const -> const string&
+{
+    FO_STACK_TRACE_ENTRY();
+
+    return GetStr(key, skip);
+}
+
+auto TextPack::GetTextCount(TextPackKey key) const -> size_t
+{
+    FO_STACK_TRACE_ENTRY();
+
+    return GetStrCount(key);
+}
+
+auto TextPack::IsTextPresent(TextPackKey key) const -> bool
+{
+    FO_STACK_TRACE_ENTRY();
+
+    return GetTextCount(key) != 0;
+}
+
+auto TextPack::GetStr(TextPackKey key) const -> const string&
+{
+    FO_STACK_TRACE_ENTRY();
+
+    const size_t str_count = _strData.count(key);
+    auto it = _strData.find(key);
 
     switch (str_count) {
     case 0:
@@ -77,12 +163,12 @@ auto TextPack::GetStr(TextPackKey num) const -> const string&
     return it->second;
 }
 
-auto TextPack::GetStr(TextPackKey num, size_t skip) const -> const string&
+auto TextPack::GetStr(TextPackKey key, size_t skip) const -> const string&
 {
     FO_STACK_TRACE_ENTRY();
 
-    const size_t str_count = _strData.count(num);
-    auto it = _strData.find(num);
+    const size_t str_count = _strData.count(key);
+    auto it = _strData.find(key);
 
     if (skip >= str_count) {
         return _emptyStr;
@@ -95,49 +181,11 @@ auto TextPack::GetStr(TextPackKey num, size_t skip) const -> const string&
     return it->second;
 }
 
-auto TextPack::GetStrCount(TextPackKey num) const -> size_t
+auto TextPack::GetStrCount(TextPackKey key) const -> size_t
 {
     FO_STACK_TRACE_ENTRY();
 
-    return _strData.count(num);
-}
-
-void TextPack::EraseStr(TextPackKey num)
-{
-    FO_STACK_TRACE_ENTRY();
-
-    _strData.erase(num);
-}
-
-void TextPack::Merge(const TextPack& other)
-{
-    FO_STACK_TRACE_ENTRY();
-
-    for (auto&& [key, value] : other._strData) {
-        AddStr(key, value);
-    }
-}
-
-void TextPack::FixStr(const TextPack& base_pack)
-{
-    FO_STACK_TRACE_ENTRY();
-
-    // Add keys that are in the base pack but not in this pack
-    for (auto&& [key, value] : base_pack._strData) {
-        if (_strData.count(key) == 0) {
-            AddStr(key, value);
-        }
-    }
-
-    // Remove keys that are not in the base pack
-    for (auto it = _strData.begin(); it != _strData.end();) {
-        if (base_pack._strData.count(it->first) == 0) {
-            it = _strData.erase(it);
-        }
-        else {
-            ++it;
-        }
-    }
+    return _strData.count(key);
 }
 
 auto TextPack::GetSize() const noexcept -> size_t
@@ -172,8 +220,11 @@ auto TextPack::GetBinaryData() const -> vector<uint8>
 
     writer.Write<uint32>(numeric_cast<uint32>(_strData.size()));
 
-    for (auto&& [num, str] : _strData) {
-        writer.Write<TextPackKey>(num);
+    for (auto&& [key, str] : _strData) {
+        WriteKeyPart(writer, key.Collection.underlying_value());
+        WriteKeyPart(writer, key.Key1);
+        WriteKeyPart(writer, key.Key2);
+        WriteKeyPart(writer, key.Key3);
         writer.Write<uint32>(numeric_cast<uint32>(str.length()));
         writer.WritePtr(str.data(), str.length());
     }
@@ -181,16 +232,27 @@ auto TextPack::GetBinaryData() const -> vector<uint8>
     return data;
 }
 
-auto TextPack::LoadFromBinaryData(const vector<uint8>& data) -> bool
+auto TextPack::LoadFromBinaryData(const vector<uint8>& data, string_view collection) -> bool
 {
     FO_STACK_TRACE_ENTRY();
 
     auto reader = DataReader {data};
+    const auto collection_key = TextPackName {MakeKeyPart(collection)};
 
     const auto count = reader.Read<uint32>();
 
     for (uint32 i = 0; i < count; i++) {
-        const auto num = reader.Read<TextPackKey>();
+        TextPackKey key;
+
+        key.Collection = TextPackName {ReadKeyPart(reader)};
+        key.Key1 = ReadKeyPart(reader);
+        key.Key2 = ReadKeyPart(reader);
+        key.Key3 = ReadKeyPart(reader);
+
+        if (!key.Collection && collection_key) {
+            key.Collection = collection_key;
+        }
+
         const auto str_len = reader.Read<uint32>();
 
         string str;
@@ -203,13 +265,13 @@ auto TextPack::LoadFromBinaryData(const vector<uint8>& data) -> bool
             str.resize(0);
         }
 
-        AddStr(num, std::move(str));
+        AddStr(key, std::move(str));
     }
 
     return true;
 }
 
-auto TextPack::LoadFromString(const string& str, HashResolver& hash_resolver) -> bool
+auto TextPack::LoadFromString(const string& str, string_view collection) -> bool
 {
     FO_STACK_TRACE_ENTRY();
 
@@ -219,61 +281,132 @@ auto TextPack::LoadFromString(const string& str, HashResolver& hash_resolver) ->
     string line;
 
     while (std::getline(sstr, line, '\n')) {
-        TextPackKey num = 0;
         size_t offset = 0;
 
-        for (auto i = 0; i < 3; i++) {
-            const auto first = line.find('{', offset);
-            auto last = line.find('}', first);
+        string token1;
+        string token2;
+        string token3;
 
-            if (first == string::npos || last == string::npos) {
-                if (i == 2 && first != string::npos) {
-                    string additional_line;
-                    while (last == string::npos && std::getline(sstr, additional_line, '\n')) {
-                        line += "\n" + additional_line;
-                        last = line.find('}', first);
-                    }
-                }
-
-                if (first == string::npos || last == string::npos) {
-                    if (i > 0 || first != string::npos) {
-                        failed = true;
-                    }
-
-                    break;
-                }
-            }
-
-            auto substr = line.substr(first + 1, last - first - 1);
-            offset = last + 1;
-
-            if (i == 0 && num == 0) {
-                num = strvex(substr).is_number() ? strvex(substr).to_int32() : hash_resolver.ToHashedString(substr).as_int32();
-            }
-            else if (i == 1 && num != 0) {
-                num += !substr.empty() ? (strvex(substr).is_number() ? strvex(substr).to_int32() : hash_resolver.ToHashedString(substr).as_int32()) : 0;
-            }
-            else if (i == 2 && num != 0) {
-                AddStr(num, std::move(substr));
-            }
-            else {
-                failed = true;
-            }
+        if (!ExtractBraceToken(line, offset, token1, false, nullptr)) {
+            continue;
         }
+        if (!ExtractBraceToken(line, offset, token2, false, nullptr)) {
+            failed = true;
+            continue;
+        }
+        if (!ExtractBraceToken(line, offset, token3, true, &sstr)) {
+            failed = true;
+            continue;
+        }
+
+        if (collection.empty() || token1.empty()) {
+            failed = true;
+            continue;
+        }
+
+        AddStr(TextPackKey::FromParts(*_hashResolver, collection, token1, token2), std::move(token3));
     }
 
     return !failed;
 }
 
-void TextPack::LoadFromMap(const map<string, string>& kv)
+void TextPack::LoadFromMap(const map<string, string>& kv, string_view collection)
 {
     FO_STACK_TRACE_ENTRY();
 
     for (auto&& [key, value] : kv) {
-        const TextPackKey num = strvex(key).to_uint32();
+        TextPackKey text_key;
 
-        if (num != 0) {
-            AddStr(num, value);
+        if (strvex(key).starts_with('{')) {
+            if (TextPackKey::Parse(*_hashResolver, key, text_key)) {
+                AddStr(text_key, value);
+            }
+        }
+        else {
+            if (!collection.empty() && !key.empty()) {
+                AddStr(TextPackKey::FromParts(*_hashResolver, collection, key), value);
+            }
+        }
+    }
+}
+
+void TextPack::LoadFromResources(FileSystem& resources, string_view language)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    auto text_files = resources.FilterFiles("fotxt-bin");
+
+    for (const auto& text_file_header : text_files) {
+        const auto text_file = File::Load(text_file_header);
+        const auto file_name = text_file.GetNameNoExt();
+
+        const auto name_triplet = strvex(file_name).split('.');
+        FO_RUNTIME_ASSERT(name_triplet.size() == 3);
+        const auto& pack_name_str = name_triplet[1];
+        const auto& lang_name = name_triplet[2];
+        FO_RUNTIME_ASSERT(!pack_name_str.empty());
+        FO_RUNTIME_ASSERT(!lang_name.empty());
+
+        if (!language.empty() && lang_name != language) {
+            continue;
+        }
+
+        if (!LoadFromBinaryData(text_file.GetData(), pack_name_str)) {
+            throw TextPackException("Invalid binary text file", text_file.GetPath());
+        }
+    }
+}
+
+void TextPack::AddStr(TextPackKey key, string_view str)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    _strData.emplace(key, string(str));
+}
+
+void TextPack::AddStr(TextPackKey key, string&& str)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    _strData.emplace(key, std::move(str));
+}
+
+void TextPack::EraseStr(TextPackKey key)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    _strData.erase(key);
+}
+
+void TextPack::Merge(const TextPack& other)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    for (auto&& [key, value] : other._strData) {
+        AddStr(key, value);
+    }
+}
+
+void TextPack::FixStr(const TextPack& base_pack)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    // Add keys that are in the base pack but not in this pack
+    for (auto&& [key, value] : base_pack._strData) {
+        const auto has_same_entry = _strData.count(key) != 0;
+
+        if (!has_same_entry) {
+            AddStr(key, value);
+        }
+    }
+
+    // Remove keys that are not in the base pack
+    for (auto it = _strData.begin(); it != _strData.end();) {
+        if (base_pack._strData.count(it->first) == 0) {
+            it = _strData.erase(it);
+        }
+        else {
+            ++it;
         }
     }
 }
@@ -347,93 +480,39 @@ void TextPack::FixPacks(const_span<string> bake_languages, vector<pair<string, m
     }
 }
 
-LanguagePack::LanguagePack(string_view lang_name, const NameResolver& name_resolver) :
-    _langName {lang_name},
-    _nameResolver {&name_resolver}
+auto TextPack::MakeKeyPart(string_view value) -> hstring
 {
     FO_STACK_TRACE_ENTRY();
 
-    _textPacks.resize(std::numeric_limits<std::underlying_type_t<TextPackName>>::max() + 1);
-    _textPacks[static_cast<size_t>(TextPackName::Items)] = SafeAlloc::MakeUnique<TextPack>();
-    _textPacks[static_cast<size_t>(TextPackName::Critters)] = SafeAlloc::MakeUnique<TextPack>();
-    _textPacks[static_cast<size_t>(TextPackName::Maps)] = SafeAlloc::MakeUnique<TextPack>();
-    _textPacks[static_cast<size_t>(TextPackName::Locations)] = SafeAlloc::MakeUnique<TextPack>();
+    return !value.empty() ? _hashResolver->ToHashedString(value) : hstring {};
 }
 
-auto LanguagePack::GetName() const noexcept -> const string&
+void TextPack::WriteKeyPart(DataWriter& writer, hstring part) const
 {
     FO_STACK_TRACE_ENTRY();
 
-    return _langName;
-}
+    const auto& str = part.as_str();
+    writer.Write<uint32>(numeric_cast<uint32>(str.length()));
 
-auto LanguagePack::GetTextPack(TextPackName pack_name) const -> const TextPack&
-{
-    FO_STACK_TRACE_ENTRY();
-
-    const auto pack_index = static_cast<size_t>(pack_name);
-    FO_RUNTIME_ASSERT(pack_index < _textPacks.size());
-
-    return _textPacks[pack_index] ? *_textPacks[pack_index] : _emptyPack;
-}
-
-auto LanguagePack::GetTextPackForEdit(TextPackName pack_name) -> TextPack&
-{
-    FO_STACK_TRACE_ENTRY();
-
-    const auto pack_index = static_cast<size_t>(pack_name);
-    FO_RUNTIME_ASSERT(pack_index < _textPacks.size());
-
-    if (!_textPacks[pack_index]) {
-        _textPacks[pack_index] = SafeAlloc::MakeUnique<TextPack>();
-    }
-
-    return *_textPacks[pack_index];
-}
-
-auto LanguagePack::ResolveTextPackName(string_view pack_name_str, bool* failed) const -> TextPackName
-{
-    FO_STACK_TRACE_ENTRY();
-
-    try {
-        return static_cast<TextPackName>(_nameResolver->ResolveEnumValue(string("TextPackName"), string(pack_name_str)));
-    }
-    catch (const EnumResolveException&) {
-        if (failed != nullptr) {
-            *failed = true;
-            return {};
-        }
-
-        throw LanguagePackException("Invalid text pack name", pack_name_str);
+    if (!str.empty()) {
+        writer.WritePtr(str.data(), str.length());
     }
 }
 
-void LanguagePack::LoadFromResources(FileSystem& resources)
+auto TextPack::ReadKeyPart(DataReader& reader) -> hstring
 {
     FO_STACK_TRACE_ENTRY();
 
-    auto text_files = resources.FilterFiles("fotxt-bin");
+    const auto str_len = reader.Read<uint32>();
 
-    for (const auto& text_file_header : text_files) {
-        const auto text_file = File::Load(text_file_header);
-        const auto file_name = text_file.GetNameNoExt();
-
-        const auto name_triplet = strvex(file_name).split('.');
-        FO_RUNTIME_ASSERT(name_triplet.size() == 3);
-        const auto& pack_name_str = name_triplet[1];
-        const auto& lang_name = name_triplet[2];
-        FO_RUNTIME_ASSERT(!pack_name_str.empty());
-        FO_RUNTIME_ASSERT(!lang_name.empty());
-
-        if (lang_name == _langName) {
-            const auto pack_name = ResolveTextPackName(pack_name_str);
-            auto& text_pack = GetTextPackForEdit(pack_name);
-
-            if (!text_pack.LoadFromBinaryData(text_file.GetData())) {
-                throw LanguagePackException("Invalid binary text file", text_file.GetPath());
-            }
-        }
+    if (str_len == 0) {
+        return {};
     }
+
+    string str;
+    str.resize(str_len);
+    reader.ReadPtr(str.data(), str_len);
+    return MakeKeyPart(str);
 }
 
 FO_END_NAMESPACE

--- a/Source/Common/TextPack.h
+++ b/Source/Common/TextPack.h
@@ -35,84 +35,121 @@
 
 #include "Common.h"
 
-#include "FileSystem.h"
-
 FO_BEGIN_NAMESPACE
 
-FO_DECLARE_EXCEPTION(LanguagePackException);
+FO_DECLARE_EXCEPTION(TextPackException);
 
-///@ ExportEnum
-enum class TextPackName : uint8
+class FileSystem;
+
+///@ ExportValueType TextPackName TextPackName Layout = hstring-value
+using TextPackName = strong_type<hstring, struct TextPackName_, strong_type_bool_test_tag, strong_type_sortings_tag>;
+
+///@ ExportValueType LanguageName LanguageName Layout = hstring-value
+using LanguageName = strong_type<hstring, struct LanguageName_, strong_type_bool_test_tag, strong_type_sortings_tag>;
+
+///@ ExportValueType TextPackKey TextPackKey Layout = TextPackName-Collection+hstring-Key1+hstring-Key2+hstring-Key3
+struct TextPackKey
 {
-    None = 0,
-    Items = 2,
-    Critters = 3,
-    Maps = 4,
-    Locations = 5,
-    Protos = 6,
-};
+    constexpr TextPackKey() noexcept = default;
+    constexpr explicit TextPackKey(hstring key1, hstring key2 = {}, hstring key3 = {}) noexcept :
+        Key1 {key1},
+        Key2 {key2},
+        Key3 {key3}
+    {
+    }
+    constexpr explicit TextPackKey(TextPackName collection, hstring key1, hstring key2 = {}, hstring key3 = {}) noexcept :
+        Collection {collection},
+        Key1 {key1},
+        Key2 {key2},
+        Key3 {key3}
+    {
+    }
 
-using TextPackKey = uint32;
+    [[nodiscard]] constexpr explicit operator bool() const noexcept { return Collection && (Key1 || Key2 || Key3); }
+    [[nodiscard]] constexpr auto operator==(const TextPackKey& other) const noexcept -> bool = default;
+    [[nodiscard]] constexpr auto operator<(const TextPackKey& other) const noexcept -> bool { return std::tie(Collection, Key1, Key2, Key3) < std::tie(other.Collection, other.Key1, other.Key2, other.Key3); }
+
+    [[nodiscard]] static auto FromParts(HashResolver& hash_resolver, string_view collection, string_view key1, string_view key2 = {}, string_view key3 = {}) -> TextPackKey;
+    [[nodiscard]] static auto FromPack(HashResolver& hash_resolver, string_view collection, string_view key1, string_view key2 = {}, string_view key3 = {}) -> TextPackKey;
+    [[nodiscard]] static auto Parse(HashResolver& hash_resolver, string_view str, TextPackKey& result) -> bool;
+
+    TextPackName Collection {};
+    hstring Key1 {};
+    hstring Key2 {};
+    hstring Key3 {};
+};
+static_assert(std::is_standard_layout_v<TextPackKey>);
+
+FO_END_NAMESPACE
+template<>
+struct FO_NAMESPACE hashing::hash<FO_NAMESPACE TextPackKey>
+{
+    using is_avalanching = void;
+
+    auto operator()(const FO_NAMESPACE TextPackKey& v) const noexcept
+    {
+        const FO_NAMESPACE hstring::hash_t hashes[] = {v.Collection.underlying_value().as_hash(), v.Key1.as_hash(), v.Key2.as_hash(), v.Key3.as_hash()};
+        return FO_NAMESPACE hashing_ex::hash(hashes, sizeof(hashes));
+    }
+};
+template<>
+struct std::formatter<FO_NAMESPACE TextPackKey> : formatter<FO_NAMESPACE string_view>
+{
+    template<typename FormatContext>
+    auto format(const FO_NAMESPACE TextPackKey& value, FormatContext& ctx) const
+    {
+        string result;
+        std::format_to(std::back_inserter(result), "{{{}}}{{{}}}{{{}}}{{{}}}", value.Collection, value.Key1, value.Key2, value.Key3);
+        return formatter<FO_NAMESPACE string_view>::format(result, ctx);
+    }
+};
+FO_BEGIN_NAMESPACE
 
 class TextPack final
 {
 public:
-    TextPack() = default;
+    explicit TextPack(HashResolver& hash_resolver);
     TextPack(const TextPack&) = default;
     TextPack(TextPack&&) noexcept = default;
     auto operator=(const TextPack&) -> TextPack& = default;
     auto operator=(TextPack&&) noexcept -> TextPack& = default;
     ~TextPack() = default;
 
-    [[nodiscard]] auto GetStr(TextPackKey num) const -> const string&;
-    [[nodiscard]] auto GetStr(TextPackKey num, size_t skip) const -> const string&;
-    [[nodiscard]] auto GetStrCount(TextPackKey num) const -> size_t;
+    [[nodiscard]] auto GetText(TextPackKey key) const -> const string&;
+    [[nodiscard]] auto GetText(TextPackKey key, size_t skip) const -> const string&;
+    [[nodiscard]] auto GetTextCount(TextPackKey key) const -> size_t;
+    [[nodiscard]] auto IsTextPresent(TextPackKey key) const -> bool;
+    [[nodiscard]] auto GetStr(TextPackKey key) const -> const string&;
+    [[nodiscard]] auto GetStr(TextPackKey key, size_t skip) const -> const string&;
+    [[nodiscard]] auto GetStrCount(TextPackKey key) const -> size_t;
     [[nodiscard]] auto GetSize() const noexcept -> size_t;
     [[nodiscard]] auto CheckIntersections(const TextPack& other) const -> bool;
     [[nodiscard]] auto GetBinaryData() const -> vector<uint8>;
 
-    auto LoadFromBinaryData(const vector<uint8>& data) -> bool;
-    auto LoadFromString(const string& str, HashResolver& hash_resolver) -> bool;
-    void LoadFromMap(const map<string, string>& kv);
-    void AddStr(TextPackKey num, string_view str);
-    void AddStr(TextPackKey num, string&& str);
-    void EraseStr(TextPackKey num);
+    auto LoadFromBinaryData(const vector<uint8>& data, string_view collection = {}) -> bool;
+    auto LoadFromString(const string& str, string_view collection = {}) -> bool;
+    void LoadFromMap(const map<string, string>& kv, string_view collection = {});
+    void LoadFromResources(FileSystem& resources, string_view language = {});
+    void AddStr(TextPackKey key, string_view str);
+    void AddStr(TextPackKey key, string&& str);
+    void EraseStr(TextPackKey key);
     void Merge(const TextPack& other);
     void FixStr(const TextPack& base_pack);
     void Clear();
 
     static void FixPacks(const_span<string> bake_languages, vector<pair<string, map<string, TextPack>>>& lang_packs);
 
+    friend struct TextPackKey;
+
 private:
+    auto MakeKeyPart(string_view value) -> hstring;
+    void WriteKeyPart(DataWriter& writer, hstring part) const;
+    auto ReadKeyPart(DataReader& reader) -> hstring;
+
+    raw_ptr<HashResolver> _hashResolver;
     multimap<TextPackKey, string> _strData {};
     string _emptyStr {};
     mutable std::mt19937 _randomGenerator {MakeSeededRandomGenerator()};
-};
-
-class LanguagePack final
-{
-public:
-    LanguagePack() = default;
-    LanguagePack(string_view lang_name, const NameResolver& name_resolver);
-    LanguagePack(const LanguagePack&) = delete;
-    LanguagePack(LanguagePack&&) noexcept = default;
-    auto operator=(const LanguagePack&) -> LanguagePack& = delete;
-    auto operator=(LanguagePack&&) noexcept -> LanguagePack& = default;
-    auto operator==(string_view lang_name) const -> bool { return lang_name == _langName; }
-    ~LanguagePack() = default;
-
-    [[nodiscard]] auto GetName() const noexcept -> const string&;
-    [[nodiscard]] auto GetTextPack(TextPackName pack_name) const -> const TextPack&;
-    [[nodiscard]] auto GetTextPackForEdit(TextPackName pack_name) -> TextPack&;
-    [[nodiscard]] auto ResolveTextPackName(string_view pack_name_str, bool* failed = nullptr) const -> TextPackName;
-
-    void LoadFromResources(FileSystem& resources);
-
-private:
-    string _langName {};
-    raw_ptr<const NameResolver> _nameResolver {};
-    vector<unique_ptr<TextPack>> _textPacks {};
-    TextPack _emptyPack {};
 };
 
 FO_END_NAMESPACE

--- a/Source/Essentials/BasicCore.h
+++ b/Source/Essentials/BasicCore.h
@@ -107,7 +107,6 @@
 
 // Custom hashmaps
 #include "ankerl/unordered_dense.h"
-#define FO_HASH_NAMESPACE ankerl::unordered_dense::
 
 // OS specific API
 #if FO_MAC || FO_IOS
@@ -217,6 +216,9 @@ using std::variant;
 
 template<typename T>
 using const_span = span<const T>;
+
+namespace hashing = ankerl::unordered_dense;
+namespace hashing_ex = ankerl::unordered_dense::detail::wyhash;
 
 // String view for null terminated string
 class string_view_nt : public string_view
@@ -592,13 +594,13 @@ FO_BEGIN_NAMESPACE
 #define FO_DECLARE_TYPE_HASHER(type) \
     FO_END_NAMESPACE \
     template<> \
-    struct FO_HASH_NAMESPACE hash<type> \
+    struct FO_NAMESPACE hashing::hash<type> \
     { \
         using is_avalanching = void; \
         auto operator()(const type& v) const noexcept \
         { \
             static_assert(std::has_unique_object_representations_v<type>); \
-            return detail::wyhash::hash(&v, sizeof(v)); \
+            return FO_NAMESPACE hashing_ex::hash(&v, sizeof(v)); \
         } \
     }; \
     FO_BEGIN_NAMESPACE
@@ -606,12 +608,12 @@ FO_BEGIN_NAMESPACE
 #define FO_DECLARE_TYPE_HASHER_EXT(type, ...) \
     FO_END_NAMESPACE \
     template<> \
-    struct FO_HASH_NAMESPACE hash<type> \
+    struct FO_NAMESPACE hashing::hash<type> \
     { \
         using is_avalanching = void; \
         auto operator()(const type& v) const noexcept \
         { \
-            return detail::wyhash::hash(__VA_ARGS__); \
+            return FO_NAMESPACE hashing_ex::hash(__VA_ARGS__); \
         } \
     }; \
     FO_BEGIN_NAMESPACE

--- a/Source/Essentials/Containers.h
+++ b/Source/Essentials/Containers.h
@@ -58,17 +58,17 @@ template<typename K, typename Cmp = std::less<>>
 using set = std::set<K, Cmp, SafeAllocator<K>>;
 
 #if FO_DEBUG
-template<typename K, typename V, typename H = FO_HASH_NAMESPACE hash<K>>
+template<typename K, typename V, typename H = hashing::hash<K>>
 using unordered_map = std::unordered_map<K, V, H, std::equal_to<>, SafeAllocator<pair<const K, V>>>;
-template<typename K, typename H = FO_HASH_NAMESPACE hash<K>>
+template<typename K, typename H = hashing::hash<K>>
 using unordered_set = std::unordered_set<K, H, std::equal_to<>, SafeAllocator<K>>;
 #else
-template<typename K, typename V, typename H = FO_HASH_NAMESPACE hash<K>>
+template<typename K, typename V, typename H = hashing::hash<K>>
 using unordered_map = ankerl::unordered_dense::segmented_map<K, V, H, std::equal_to<>, SafeAllocator<pair<K, V>>>;
-template<typename K, typename H = FO_HASH_NAMESPACE hash<K>>
+template<typename K, typename H = hashing::hash<K>>
 using unordered_set = ankerl::unordered_dense::segmented_set<K, H, std::equal_to<>, SafeAllocator<K>>;
 #endif
-template<typename K, typename V, typename H = FO_HASH_NAMESPACE hash<K>>
+template<typename K, typename V, typename H = hashing::hash<K>>
 using unordered_multimap = std::unordered_multimap<K, V, H, std::equal_to<>, SafeAllocator<pair<const K, V>>>;
 
 template<typename T, unsigned InlineCapacity>
@@ -90,11 +90,11 @@ concept map_collection = specialization_of<T, std::map> || specialization_of<T, 
 // String formatter
 FO_END_NAMESPACE
 template<>
-struct FO_HASH_NAMESPACE hash<FO_NAMESPACE string>
+struct FO_NAMESPACE hashing::hash<FO_NAMESPACE string>
 {
     using is_transparent = void;
     using is_avalanching = void;
-    auto operator()(FO_NAMESPACE string_view str) const noexcept -> uint64_t { return hash<FO_NAMESPACE string_view> {}(str); }
+    auto operator()(FO_NAMESPACE string_view str) const noexcept -> uint64_t { return FO_NAMESPACE hashing::hash<FO_NAMESPACE string_view> {}(str); }
 };
 FO_BEGIN_NAMESPACE
 

--- a/Source/Essentials/HashedString.cpp
+++ b/Source/Essentials/HashedString.cpp
@@ -37,17 +37,23 @@ FO_BEGIN_NAMESPACE
 
 hstring::entry hstring::_zeroEntry;
 
+HashStorage::HashStorage(HashFunc hash_func) :
+    _hashFunc {hash_func}
+{
+    FO_STACK_TRACE_ENTRY();
+}
+
 auto HashStorage::ToHashedString(string_view s) -> hstring
 {
     FO_NO_STACK_TRACE_ENTRY();
 
-    static_assert(std::same_as<hstring::hash_t, decltype(Hashing::MurmurHash2({}, {}))>);
+    static_assert(std::same_as<hstring::hash_t, decltype(_hashFunc({}, {}))>);
 
     if (s.empty()) {
         return {};
     }
 
-    const auto hash_value = Hashing::MurmurHash2(s.data(), s.length());
+    const auto hash_value = _hashFunc(s.data(), s.length());
     FO_RUNTIME_ASSERT(hash_value != 0);
 
     {
@@ -124,122 +130,6 @@ auto HashStorage::ResolveHash(hstring::hash_t h, bool* failed) const noexcept ->
     }
 
     return {};
-}
-
-auto Hashing::MurmurHash2(const void* data, size_t len) noexcept -> uint32
-{
-    FO_NO_STACK_TRACE_ENTRY();
-
-    if (len == 0) {
-        return 0;
-    }
-
-    constexpr uint32 seed = 0;
-    constexpr uint32 m = 0x5BD1E995;
-    constexpr auto r = 24;
-    const auto* pdata = static_cast<const uint8*>(data);
-    auto h = seed ^ static_cast<uint32>(len);
-
-    while (len >= 4) {
-        uint32 k = pdata[0];
-        k |= pdata[1] << 8;
-        k |= pdata[2] << 16;
-        k |= pdata[3] << 24;
-
-        k *= m;
-        k ^= k >> r;
-        k *= m;
-
-        h *= m;
-        h ^= k;
-
-        pdata += 4;
-        len -= 4;
-    }
-
-    switch (len) {
-    case 3:
-        h ^= pdata[2] << 16;
-        [[fallthrough]];
-    case 2:
-        h ^= pdata[1] << 8;
-        [[fallthrough]];
-    case 1:
-        h ^= pdata[0];
-        h *= m;
-        [[fallthrough]];
-    default:
-        break;
-    }
-
-    h ^= h >> 13;
-    h *= m;
-    h ^= h >> 15;
-
-    return h;
-}
-
-auto Hashing::MurmurHash2_64(const void* data, size_t len) noexcept -> uint64
-{
-    FO_NO_STACK_TRACE_ENTRY();
-
-    if (len == 0) {
-        return 0;
-    }
-
-    constexpr uint32 seed = 0;
-    constexpr auto m = 0xc6a4a7935bd1e995ULL;
-    constexpr auto r = 47;
-    const auto* pdata = static_cast<const uint8*>(data);
-    const auto* pdata2 = reinterpret_cast<const uint64*>(pdata);
-    const auto* end = pdata2 + len / 8;
-    auto h = seed ^ len * m;
-
-    while (pdata2 != end) {
-        auto k = *pdata2++;
-
-        k *= m;
-        k ^= k >> r;
-        k *= m;
-
-        h ^= k;
-        h *= m;
-    }
-
-    const auto* data3 = reinterpret_cast<const uint8*>(pdata2);
-
-    switch (len & 7) {
-    case 7:
-        h ^= static_cast<uint64>(data3[6]) << 48;
-        [[fallthrough]];
-    case 6:
-        h ^= static_cast<uint64>(data3[5]) << 40;
-        [[fallthrough]];
-    case 5:
-        h ^= static_cast<uint64>(data3[4]) << 32;
-        [[fallthrough]];
-    case 4:
-        h ^= static_cast<uint64>(data3[3]) << 24;
-        [[fallthrough]];
-    case 3:
-        h ^= static_cast<uint64>(data3[2]) << 16;
-        [[fallthrough]];
-    case 2:
-        h ^= static_cast<uint64>(data3[1]) << 8;
-        [[fallthrough]];
-    case 1:
-        h ^= static_cast<uint64>(data3[0]);
-        h *= m;
-        [[fallthrough]];
-    default:
-        break;
-    }
-
-    h ^= h >> r;
-    h *= m;
-    h ^= h >> r;
-
-    return h;
 }
 
 FO_END_NAMESPACE

--- a/Source/Essentials/HashedString.h
+++ b/Source/Essentials/HashedString.h
@@ -39,10 +39,9 @@
 
 FO_BEGIN_NAMESPACE
 
-// Hashing
 struct hstring
 {
-    using hash_t = uint32;
+    using hash_t = uint64;
 
     struct entry
     {
@@ -67,8 +66,8 @@ struct hstring
     [[nodiscard]] constexpr auto operator==(const hstring& other) const noexcept -> bool { return _entry->Hash == other._entry->Hash; }
     [[nodiscard]] constexpr auto operator<(const hstring& other) const noexcept -> bool { return _entry->Hash < other._entry->Hash; }
     [[nodiscard]] constexpr auto as_hash() const noexcept -> hash_t { return _entry->Hash; }
-    [[nodiscard]] constexpr auto as_int32() const noexcept -> int32 { return std::bit_cast<int32>(_entry->Hash); }
-    [[nodiscard]] constexpr auto as_uint32() const noexcept -> uint32 { return _entry->Hash; }
+    [[nodiscard]] constexpr auto as_int64() const noexcept -> int64 { return std::bit_cast<int64>(_entry->Hash); }
+    [[nodiscard]] constexpr auto as_uint64() const noexcept -> uint64 { return _entry->Hash; }
     [[nodiscard]] constexpr auto as_str() const noexcept -> const string& { return _entry->Str; }
     [[nodiscard]] constexpr auto c_str() const noexcept -> const char* { return _entry->Str.c_str(); }
 
@@ -77,7 +76,7 @@ private:
 
     const entry* _entry {&_zeroEntry};
 };
-static_assert(sizeof(hstring::hash_t) == 4);
+static_assert(sizeof(hstring::hash_t) == 8);
 static_assert(std::is_standard_layout_v<hstring>);
 FO_DECLARE_TYPE_HASHER_EXT(FO_NAMESPACE hstring, v.as_hash());
 
@@ -93,7 +92,6 @@ struct std::formatter<FO_NAMESPACE hstring> : formatter<FO_NAMESPACE string_view
 };
 FO_BEGIN_NAMESPACE
 
-// Hashing
 FO_DECLARE_EXCEPTION(HashResolveException);
 FO_DECLARE_EXCEPTION(HashCollisionException);
 
@@ -109,22 +107,17 @@ public:
 class HashStorage : public HashResolver
 {
 public:
+    using HashFunc = uint64 (*)(const void* data, size_t len);
+
+    explicit HashStorage(HashFunc hash_func = hashing_ex::hash);
     auto ToHashedString(string_view s) -> hstring override;
     auto ResolveHash(hstring::hash_t h) const -> hstring override;
     auto ResolveHash(hstring::hash_t h, bool* failed) const noexcept -> hstring override;
 
 private:
+    HashFunc _hashFunc;
     unordered_map<hstring::hash_t, hstring::entry> _hashStorage {};
     mutable std::shared_mutex _hashStorageLocker {};
-};
-
-class Hashing final
-{
-public:
-    Hashing() = delete;
-
-    [[nodiscard]] static auto MurmurHash2(const void* data, size_t len) noexcept -> uint32;
-    [[nodiscard]] static auto MurmurHash2_64(const void* data, size_t len) noexcept -> uint64;
 };
 
 FO_END_NAMESPACE

--- a/Source/Essentials/SmartPointers.h
+++ b/Source/Essentials/SmartPointers.h
@@ -210,19 +210,19 @@ static_assert(std::is_standard_layout_v<raw_ptr<int32>>);
 inline auto ptr_hash(const void* p) noexcept -> size_t
 {
     if constexpr (sizeof(p) == sizeof(uint64_t)) {
-        return FO_HASH_NAMESPACE detail::wyhash::hash(static_cast<uint64_t>(reinterpret_cast<size_t>(p)));
+        return hashing_ex::hash(static_cast<uint64_t>(reinterpret_cast<size_t>(p)));
     }
     else if constexpr (sizeof(p) < sizeof(uint64_t)) {
-        return static_cast<size_t>(FO_HASH_NAMESPACE detail::wyhash::hash(static_cast<uint64_t>(reinterpret_cast<size_t>(p))));
+        return static_cast<size_t>(hashing_ex::hash(static_cast<uint64_t>(reinterpret_cast<size_t>(p))));
     }
     else {
-        return FO_HASH_NAMESPACE detail::wyhash::hash(static_cast<const void*>(&p), sizeof(p));
+        return hashing_ex::hash(static_cast<const void*>(&p), sizeof(p));
     }
 }
 
 FO_END_NAMESPACE
 template<typename T>
-struct FO_HASH_NAMESPACE hash<FO_NAMESPACE raw_ptr<T>>
+struct FO_NAMESPACE hashing::hash<FO_NAMESPACE raw_ptr<T>>
 {
     using is_avalanching = void;
     auto operator()(const FO_NAMESPACE raw_ptr<T>& v) const noexcept -> size_t { return ptr_hash(v.get()); }
@@ -332,7 +332,7 @@ static_assert(std::is_standard_layout_v<unique_ptr<int32>>);
 
 FO_END_NAMESPACE
 template<typename T>
-struct FO_HASH_NAMESPACE hash<FO_NAMESPACE unique_ptr<T>>
+struct FO_NAMESPACE hashing::hash<FO_NAMESPACE unique_ptr<T>>
 {
     using is_avalanching = void;
     auto operator()(const FO_NAMESPACE unique_ptr<T>& v) const noexcept -> size_t { return ptr_hash(v.get()); }
@@ -504,7 +504,7 @@ static_assert(std::is_standard_layout_v<refcount_ptr<int32>>);
 
 FO_END_NAMESPACE
 template<typename T>
-struct FO_HASH_NAMESPACE hash<FO_NAMESPACE refcount_ptr<T>>
+struct FO_NAMESPACE hashing::hash<FO_NAMESPACE refcount_ptr<T>>
 {
     using is_avalanching = void;
     auto operator()(const FO_NAMESPACE refcount_ptr<T>& v) const noexcept -> size_t { return ptr_hash(v.get()); }
@@ -663,7 +663,7 @@ using unique_del_ptr = propagate_const<std::unique_ptr<T, function<void(T*)>>>;
 
 FO_END_NAMESPACE
 template<typename T>
-struct FO_HASH_NAMESPACE hash<FO_NAMESPACE propagate_const<T>>
+struct FO_NAMESPACE hashing::hash<FO_NAMESPACE propagate_const<T>>
 {
     using is_avalanching = void;
     auto operator()(const FO_NAMESPACE propagate_const<T>& v) const noexcept -> size_t { return ptr_hash(v.get()); }

--- a/Source/Essentials/StrongType.h
+++ b/Source/Essentials/StrongType.h
@@ -45,13 +45,17 @@ struct strong_type_arithmetics_tag
 {
 };
 
+struct strong_type_sortings_tag
+{
+};
+
 template<typename T, typename Tag, class... Opts>
-    requires(std::is_arithmetic_v<T>)
 struct strong_type
 {
     using underlying_type = T;
     static constexpr bool has_bool_test = sizeof...(Opts) != 0 && (std::same_as<Opts, strong_type_bool_test_tag> || ...);
     static constexpr bool has_arithmetics = sizeof...(Opts) != 0 && (std::same_as<Opts, strong_type_arithmetics_tag> || ...);
+    static constexpr bool has_sorting = sizeof...(Opts) != 0 && (std::same_as<Opts, strong_type_sortings_tag> || ...);
 
     constexpr strong_type() noexcept = default;
     constexpr explicit strong_type(underlying_type v) noexcept :
@@ -71,10 +75,26 @@ struct strong_type
     }
 
     [[nodiscard]] constexpr auto operator==(const strong_type& other) const noexcept -> bool { return _value == other._value; }
-    [[nodiscard]] constexpr auto operator<(const strong_type& other) const noexcept -> bool { return _value < other._value; }
-    [[nodiscard]] constexpr auto operator<=(const strong_type& other) const noexcept -> bool { return _value <= other._value; }
-    [[nodiscard]] constexpr auto operator>(const strong_type& other) const noexcept -> bool { return _value > other._value; }
-    [[nodiscard]] constexpr auto operator>=(const strong_type& other) const noexcept -> bool { return _value >= other._value; }
+    [[nodiscard]] constexpr auto operator<(const strong_type& other) const noexcept -> bool
+        requires(has_arithmetics || has_sorting)
+    {
+        return _value < other._value;
+    }
+    [[nodiscard]] constexpr auto operator<=(const strong_type& other) const noexcept -> bool
+        requires(has_arithmetics)
+    {
+        return _value <= other._value;
+    }
+    [[nodiscard]] constexpr auto operator>(const strong_type& other) const noexcept -> bool
+        requires(has_arithmetics)
+    {
+        return _value > other._value;
+    }
+    [[nodiscard]] constexpr auto operator>=(const strong_type& other) const noexcept -> bool
+        requires(has_arithmetics)
+    {
+        return _value >= other._value;
+    }
 
     [[nodiscard]] constexpr auto operator+(const strong_type& other) const noexcept -> strong_type
         requires(has_arithmetics)
@@ -151,17 +171,17 @@ FO_BEGIN_NAMESPACE
 FO_END_NAMESPACE
 template<typename T>
     requires(FO_NAMESPACE some_strong_type<T>)
-struct FO_HASH_NAMESPACE hash<T>
+struct FO_NAMESPACE hashing::hash<T>
 {
     using is_avalanching = void;
     auto operator()(const T& v) const noexcept -> size_t
     {
         static_assert(std::has_unique_object_representations_v<T>);
         if constexpr (sizeof(v) <= sizeof(uint64_t)) {
-            return static_cast<size_t>(detail::wyhash::hash(v.underlying_value()));
+            return static_cast<size_t>(FO_NAMESPACE hashing_ex::hash(v.underlying_value()));
         }
         else {
-            return static_cast<size_t>(detail::wyhash::hash(&v, sizeof(v)));
+            return static_cast<size_t>(FO_NAMESPACE hashing_ex::hash(&v, sizeof(v)));
         }
     }
 };

--- a/Source/Frontend/Rendering.cpp
+++ b/Source/Frontend/Rendering.cpp
@@ -75,7 +75,7 @@ RenderEffect::RenderEffect(EffectUsage usage, string_view name, const RenderEffe
     FO_STACK_TRACE_ENTRY();
 
     const auto fofx_content = loader(name);
-    const auto fofx = ConfigFile(name, fofx_content, nullptr, ConfigFileOption::CollectContent);
+    const auto fofx = ConfigFile(name, fofx_content, ConfigFileOption::CollectContent);
     FO_RUNTIME_ASSERT(fofx.HasSection("Effect"));
 
     const auto passes = fofx.GetAsInt("Effect", "Passes", 1);

--- a/Source/Scripting/AngelScript/AngelScriptRemoteCalls.cpp
+++ b/Source/Scripting/AngelScript/AngelScriptRemoteCalls.cpp
@@ -54,7 +54,7 @@ static void OutboundRemoteCallFunc(AngelScript::asIScriptGeneric* gen)
     vector<uint8> data;
     DataWriter writer(data);
 
-    const auto write_simple = [&](const void* ptr, const BaseTypeDesc& type) {
+    const function<void(const void*, const BaseTypeDesc&)> write_simple = [&](const void* ptr, const BaseTypeDesc& type) {
         if (type.IsPrimitive) {
             VisitBaseTypePrimitive(ptr, type, [&](auto&& v) {
                 using t = std::decay_t<decltype(v)>;
@@ -75,7 +75,9 @@ static void OutboundRemoteCallFunc(AngelScript::asIScriptGeneric* gen)
             writer.Write<hstring::hash_t>(hstr.as_hash());
         }
         else if (type.IsStruct) {
-            writer.WritePtr(ptr, type.Size);
+            for (const auto& field : type.StructLayout->Fields) {
+                write_simple(static_cast<const uint8*>(ptr) + field.Offset, field.Type);
+            }
         }
         else {
             throw NotSupportedException(FO_LINE_STR);
@@ -150,10 +152,10 @@ static void InboundRemoteCallHandler(const RemoteCallDesc& inbound_call, Entity*
     auto* as_engine = func->GetEngine();
     MutableDataReader reader(data);
 
-    using possible_types = variant<int32, string, hstring, refcount_ptr<ScriptArray>, refcount_ptr<ScriptDict>>;
+    using possible_types = variant<int32, string, hstring, vector<uint8>, refcount_ptr<ScriptArray>, refcount_ptr<ScriptDict>>;
     list<possible_types> temp_data;
 
-    const auto read_simple = [&](const BaseTypeDesc& type) -> void* {
+    const function<void*(const BaseTypeDesc&)> read_simple = [&](const BaseTypeDesc& type) -> void* {
         if (type.IsPrimitive) {
             return reader.ReadPtr<void>(type.Size);
         }
@@ -172,7 +174,12 @@ static void InboundRemoteCallHandler(const RemoteCallDesc& inbound_call, Entity*
             return cast_to_void(&std::get<hstring>(temp_data.emplace_back(hstring(hstr))));
         }
         else if (type.IsStruct) {
-            return reader.ReadPtr<void>(type.Size);
+            auto& buf = std::get<vector<uint8>>(temp_data.emplace_back(vector<uint8>(type.Size, 0)));
+            for (const auto& field : type.StructLayout->Fields) {
+                void* field_data = read_simple(field.Type);
+                MemCopy(buf.data() + field.Offset, field_data, field.Type.Size);
+            }
+            return cast_to_void(buf.data());
         }
         else {
             FO_UNREACHABLE_PLACE();

--- a/Source/Scripting/AngelScript/AngelScriptTypes.cpp
+++ b/Source/Scripting/AngelScript/AngelScriptTypes.cpp
@@ -301,14 +301,6 @@ static void HashedString_Assign(hstring& self, const hstring& other)
 }
 
 template<typename T>
-static auto HstringWrapper_Cmp(const T& self, const T& other) -> int32
-{
-    FO_NO_STACK_TRACE_ENTRY();
-
-    return self < other ? -1 : (other < self ? 1 : 0);
-}
-
-template<typename T>
 static auto HstringWrapper_HstringCast(const T& self) -> hstring
 {
     FO_NO_STACK_TRACE_ENTRY();
@@ -1144,7 +1136,7 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
         const auto& type = meta->GetBaseType("TextPackName");
         registered_types.emplace(type.Name);
         register_metadata_type_common(type);
-        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "int opCmp(const TextPackName&in other) const", FO_SCRIPT_FUNC_THIS(HstringWrapper_Cmp<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "int opCmp(const TextPackName&in other) const", FO_SCRIPT_FUNC_THIS(Type_Cmp<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "string get_str() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "string opImplCast() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "string opImplConv() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
@@ -1159,7 +1151,7 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
         const auto& type = meta->GetBaseType("LanguageName");
         registered_types.emplace(type.Name);
         register_metadata_type_common(type);
-        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "int opCmp(const LanguageName&in other) const", FO_SCRIPT_FUNC_THIS(HstringWrapper_Cmp<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "int opCmp(const LanguageName&in other) const", FO_SCRIPT_FUNC_THIS(Type_Cmp<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "string get_str() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "string opImplCast() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "string opImplConv() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
@@ -1180,7 +1172,7 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
         FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const hstring &in key1, const string &in key2)", FO_SCRIPT_GENERIC(TextPackKey_ConstructH2), FO_SCRIPT_GENERIC_CONV));
         FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const string &in key1, const string &in key2, const string &in key3)", FO_SCRIPT_GENERIC(TextPackKey_Construct3), FO_SCRIPT_GENERIC_CONV));
         FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const hstring &in key1, const string &in key2, const string &in key3)", FO_SCRIPT_GENERIC(TextPackKey_ConstructH3), FO_SCRIPT_GENERIC_CONV));
-        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackKey", "int opCmp(const TextPackKey&in other) const", FO_SCRIPT_GENERIC(GenericType_Cmp), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackKey", "int opCmp(const TextPackKey&in other) const", FO_SCRIPT_GENERIC(Type_Cmp<TextPackKey>), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackKey", "string get_str() const", FO_SCRIPT_GENERIC(GenericType_GetStr), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackKey", "any opImplConv() const", FO_SCRIPT_GENERIC(GenericType_AnyConv), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "TextPackKey opImplConv() const", FO_SCRIPT_GENERIC(GenericType_AnyConvRev), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));

--- a/Source/Scripting/AngelScript/AngelScriptTypes.cpp
+++ b/Source/Scripting/AngelScript/AngelScriptTypes.cpp
@@ -41,6 +41,7 @@
 #include "AngelScriptString.h"
 #include "EngineBase.h"
 #include "Geometry.h"
+#include "TextPack.h"
 
 FO_BEGIN_NAMESPACE
 
@@ -99,6 +100,22 @@ static auto Type_Equals(const T& self, const U& other) -> bool
     return self == other;
 }
 
+static void DefaultInitStructFields(void* obj, const BaseTypeDesc& type)
+{
+    MemFill(obj, 0, type.Size);
+
+    if (type.StructLayout != nullptr) {
+        for (const auto& field : type.StructLayout->Fields) {
+            if (field.Type.IsHashedString) {
+                new (static_cast<uint8*>(obj) + field.Offset) hstring();
+            }
+            else if (field.Type.IsStruct) {
+                DefaultInitStructFields(static_cast<uint8*>(obj) + field.Offset, field.Type);
+            }
+        }
+    }
+}
+
 static void GenericType_Construct(AngelScript::asIScriptGeneric* gen)
 {
     FO_NO_STACK_TRACE_ENTRY();
@@ -106,7 +123,7 @@ static void GenericType_Construct(AngelScript::asIScriptGeneric* gen)
     const auto& type = *cast_from_void<const BaseTypeDesc*>(gen->GetAuxiliary());
     auto* obj = gen->GetObject();
 
-    MemFill(obj, 0, type.Size);
+    DefaultInitStructFields(obj, type);
 }
 
 static void GenericType_ConstructCopy(AngelScript::asIScriptGeneric* gen)
@@ -179,11 +196,12 @@ static void GenericType_AnyConvRev(AngelScript::asIScriptGeneric* gen)
     const auto& type = *cast_from_void<const BaseTypeDesc*>(gen->GetAuxiliary());
     const auto& obj = *cast_from_void<any_t*>(gen->GetObject());
     const auto tokens = strvex(obj).split(' ');
+    const auto* meta = GetEngineMetadata(gen->GetEngine());
 
     void* result = gen->GetAddressOfReturnLocation();
     size_t index = 0;
 
-    VisitBaseTypePrimitive(result, type, [&index, &tokens](auto&& v) {
+    VisitBaseTypePrimitive(result, type, [&index, &tokens, meta](auto&& v) {
         using T = std::decay_t<decltype(v)>;
 
         if (index >= tokens.size()) {
@@ -198,6 +216,9 @@ static void GenericType_AnyConvRev(AngelScript::asIScriptGeneric* gen)
         }
         else if constexpr (std::is_floating_point_v<T>) {
             v = numeric_cast<T>(strvex(tokens[index]).to_float64());
+        }
+        else if constexpr (std::is_same_v<T, hstring>) {
+            v = meta->Hashes.ToHashedString(tokens[index]);
         }
 
         index++;
@@ -263,28 +284,6 @@ static void HashedString_Destruct(hstring* self)
     self->~hstring();
 }
 
-static void HashedString_IsValidHash(AngelScript::asIScriptGeneric* gen)
-{
-    FO_NO_STACK_TRACE_ENTRY();
-
-    const auto hash = *cast_from_void<const hstring::hash_t*>(gen->GetAddressOfArg(0));
-    const auto* meta = GetEngineMetadata(gen->GetEngine());
-    bool failed = false;
-    const auto hstr = meta->Hashes.ResolveHash(hash, &failed);
-    ignore_unused(hstr);
-    new (gen->GetAddressOfReturnLocation()) bool(!failed);
-}
-
-static void HashedString_CreateFromHash(AngelScript::asIScriptGeneric* gen)
-{
-    FO_NO_STACK_TRACE_ENTRY();
-
-    const auto hash = *cast_from_void<const hstring::hash_t*>(gen->GetAddressOfArg(0));
-    const auto* meta = GetEngineMetadata(gen->GetEngine());
-    const auto hstr = meta->Hashes.ResolveHash(hash);
-    new (gen->GetAddressOfReturnLocation()) hstring(hstr);
-}
-
 static void HashedString_ConstructCopy(hstring* self, const hstring& other)
 {
     FO_NO_STACK_TRACE_ENTRY();
@@ -297,6 +296,120 @@ static void HashedString_Assign(hstring& self, const hstring& other)
     FO_NO_STACK_TRACE_ENTRY();
 
     self = other;
+}
+
+template<typename T>
+static auto HstringWrapper_Cmp(const T& self, const T& other) -> int32
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    return self < other ? -1 : (other < self ? 1 : 0);
+}
+
+template<typename T>
+static auto HstringWrapper_HstringCast(const T& self) -> hstring
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    return self.underlying_value();
+}
+
+template<typename T>
+static auto HstringWrapper_StringCast(const T& self) -> string
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    return strex("{}", self);
+}
+
+template<typename T>
+static auto HstringWrapper_AnyConv(const T& self) -> any_t
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    return any_t(strex("{}", self).str());
+}
+
+template<typename T>
+static void HstringWrapper_AnyConvRev(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    const auto* self = cast_from_void<any_t*>(gen->GetObject());
+    const auto* meta = GetEngineMetadata(gen->GetEngine());
+    new (gen->GetAddressOfReturnLocation()) T(meta->Hashes.ToHashedString(*self));
+}
+
+static void TextPackKey_ConstructFromGen(AngelScript::asIScriptGeneric* gen, bool hstring_key1)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    const auto* meta = GetEngineMetadata(gen->GetEngine());
+    auto* self = static_cast<TextPackKey*>(gen->GetObject());
+    const auto& collection = **static_cast<const TextPackName**>(gen->GetAddressOfArg(0));
+    const auto arg_count = gen->GetArgCount();
+
+    string_view key1;
+    string_view key2;
+    string_view key3;
+
+    if (hstring_key1) {
+        key1 = (*static_cast<const hstring**>(gen->GetAddressOfArg(1)))->as_str();
+    }
+    else {
+        key1 = **static_cast<const string**>(gen->GetAddressOfArg(1));
+    }
+
+    if (arg_count >= 3) {
+        key2 = **static_cast<const string**>(gen->GetAddressOfArg(2));
+    }
+    if (arg_count >= 4) {
+        key3 = **static_cast<const string**>(gen->GetAddressOfArg(3));
+    }
+
+    new (self) TextPackKey(TextPackKey::FromPack(meta->Hashes, collection.underlying_value(), key1, key2, key3));
+}
+
+static void TextPackKey_Construct1(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    TextPackKey_ConstructFromGen(gen, false);
+}
+
+static void TextPackKey_ConstructH1(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    TextPackKey_ConstructFromGen(gen, true);
+}
+
+static void TextPackKey_Construct2(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    TextPackKey_ConstructFromGen(gen, false);
+}
+
+static void TextPackKey_ConstructH2(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    TextPackKey_ConstructFromGen(gen, true);
+}
+
+static void TextPackKey_Construct3(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    TextPackKey_ConstructFromGen(gen, false);
+}
+
+static void TextPackKey_ConstructH3(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    TextPackKey_ConstructFromGen(gen, true);
 }
 
 static auto HashedString_EqualsString(const hstring& self, const string& other) -> bool
@@ -327,11 +440,11 @@ static auto HashedString_GetString(const hstring& self) -> string
     return string(self.as_str());
 }
 
-static auto HashedString_GetHash(const hstring& self) -> int32
+static auto HashedString_GetHash(const hstring& self) -> int64
 {
     FO_NO_STACK_TRACE_ENTRY();
 
-    return self.as_int32();
+    return self.as_int64();
 }
 
 static void String_ToHashedString(AngelScript::asIScriptGeneric* gen)
@@ -344,11 +457,11 @@ static void String_ToHashedString(AngelScript::asIScriptGeneric* gen)
     new (gen->GetAddressOfReturnLocation()) hstring(hstr);
 }
 
-static auto HashedString_GetUHash(const hstring& self) -> uint32
+static auto HashedString_GetUHash(const hstring& self) -> uint64
 {
     FO_NO_STACK_TRACE_ENTRY();
 
-    return self.as_uint32();
+    return self.as_uint64();
 }
 
 static void Any_Construct(any_t* self)
@@ -388,10 +501,77 @@ static auto Any_Assign(any_t& self, const any_t& other) -> any_t&
     return self;
 }
 
+static auto Any_MakeEnumValue(const EngineMetadata* meta, string_view enum_name, int32 enum_value) -> any_t
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    bool failed = false;
+    const auto& enum_value_name = meta->ResolveEnumValueName(enum_name, enum_value, &failed);
+
+    if (failed) {
+        throw ScriptException("Invalid enum value for any conversion", enum_name, enum_value);
+    }
+
+    return any_t {strex("{}::{}", enum_name, enum_value_name).str()};
+}
+
+static void Any_ConstructFromEnum(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    const auto* meta = GetEngineMetadata(gen->GetEngine());
+    const auto& enum_name = *cast_from_void<const string*>(gen->GetAuxiliary());
+    const auto enum_value = *cast_from_void<const int32*>(gen->GetAddressOfArg(0));
+    auto* self = cast_from_void<any_t*>(gen->GetObject());
+
+    new (self) any_t(Any_MakeEnumValue(meta, enum_name, enum_value));
+}
+
+static auto Any_ResolveEnumValue(const any_t& self, const EngineMetadata* meta, string_view enum_name) -> int32
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    const auto self_view = string_view {self};
+    bool failed = false;
+    int32 enum_value = 0;
+
+    if (const auto sep_pos = self_view.find("::"); sep_pos != string_view::npos) {
+        const auto parsed_enum_name = self_view.substr(0, sep_pos);
+        const auto parsed_value_name = self_view.substr(sep_pos + 2);
+
+        if (parsed_enum_name != enum_name) {
+            throw ScriptException("Invalid enum type for any conversion", enum_name, self_view);
+        }
+
+        enum_value = meta->ResolveEnumValue(enum_name, parsed_value_name, &failed);
+    }
+    else {
+        enum_value = meta->ResolveEnumValue(enum_name, self_view, &failed);
+    }
+
+    if (failed) {
+        throw ScriptException("Invalid enum value for any conversion", enum_name, self_view);
+    }
+
+    return enum_value;
+}
+
+static void Any_ConvEnum(AngelScript::asIScriptGeneric* gen)
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    const auto* meta = GetEngineMetadata(gen->GetEngine());
+    const auto& enum_name = *cast_from_void<const string*>(gen->GetAuxiliary());
+    const auto* self = cast_from_void<any_t*>(gen->GetObject());
+    const auto enum_value = Any_ResolveEnumValue(*self, meta, enum_name);
+
+    new (gen->GetAddressOfReturnLocation()) int32(enum_value);
+}
+
 template<typename T>
 static auto Any_Conv(const any_t& self) -> T
 {
-    FO_STACK_TRACE_ENTRY();
+    FO_NO_STACK_TRACE_ENTRY();
 
     if constexpr (std::same_as<T, bool>) {
         return strvex(self).to_bool();
@@ -424,11 +604,41 @@ static void Any_ConvGen(AngelScript::asIScriptGeneric* gen)
 {
     FO_NO_STACK_TRACE_ENTRY();
 
-    if constexpr (std::same_as<T, hstring>) {
-        const auto* self = cast_from_void<any_t*>(gen->GetObject());
-        const auto* meta = GetEngineMetadata(gen->GetEngine());
-        const auto hstr = meta->Hashes.ToHashedString(*self);
-        new (gen->GetAddressOfReturnLocation()) hstring(hstr);
+    const auto* self = cast_from_void<any_t*>(gen->GetObject());
+    const auto* meta = GetEngineMetadata(gen->GetEngine());
+
+    if constexpr (std::integral<T>) {
+        const auto self_view = string_view {*self};
+
+        T result;
+
+        if (self_view.empty()) {
+            result = T {};
+        }
+        else if (strvex(self_view).is_explicit_bool()) {
+            result = strvex(self_view).to_bool() ? 1 : 0;
+        }
+        else if (strvex(self_view).is_number()) {
+            result = numeric_cast<T>(strvex(self_view).to_int64());
+        }
+        else {
+            bool failed = false;
+            const auto resolved = meta->ResolveEnumValue(self_view, &failed);
+
+            if (failed) {
+                throw ScriptException("Invalid int value for any conversion", self_view);
+            }
+
+            result = numeric_cast<T>(resolved);
+        }
+
+        new (gen->GetAddressOfReturnLocation()) T(result);
+    }
+    else if constexpr (std::same_as<T, hstring>) {
+        new (gen->GetAddressOfReturnLocation()) hstring(meta->Hashes.ToHashedString(*self));
+    }
+    else {
+        static_assert(always_false_v<T>, "Unsupported type for any conversion");
     }
 }
 
@@ -705,8 +915,6 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
     FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("hstring", AngelScript::asBEHAVE_CONSTRUCT, "void f()", FO_SCRIPT_FUNC_THIS(HashedString_Construct), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("hstring", AngelScript::asBEHAVE_CONSTRUCT, "void f(const hstring &in)", FO_SCRIPT_FUNC_THIS(HashedString_ConstructCopy), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("hstring", AngelScript::asBEHAVE_DESTRUCT, "void f()", FO_SCRIPT_FUNC_THIS(HashedString_Destruct), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterGlobalFunction("bool hstring_isValidHash(int h)", FO_SCRIPT_GENERIC(HashedString_IsValidHash), FO_SCRIPT_GENERIC_CONV));
-    FO_AS_VERIFY(as_engine->RegisterGlobalFunction("hstring hstring_fromHash(int h)", FO_SCRIPT_GENERIC(HashedString_CreateFromHash), FO_SCRIPT_GENERIC_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "hstring& opAssign(const hstring &in)", FO_SCRIPT_FUNC_THIS(HashedString_Assign), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "int opCmp(const hstring &in) const", FO_SCRIPT_FUNC_THIS(Type_Cmp<hstring>), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "bool opEquals(const hstring &in) const", FO_SCRIPT_FUNC_THIS(Type_Equals<hstring>), FO_SCRIPT_FUNC_THIS_CONV));
@@ -714,8 +922,8 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "string opImplCast() const", FO_SCRIPT_FUNC_THIS(HashedString_StringCast), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "string opImplConv() const", FO_SCRIPT_FUNC_THIS(HashedString_StringConv), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "string get_str() const", FO_SCRIPT_FUNC_THIS(HashedString_GetString), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "int get_hash() const", FO_SCRIPT_FUNC_THIS(HashedString_GetHash), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "uint get_uhash() const", FO_SCRIPT_FUNC_THIS(HashedString_GetUHash), FO_SCRIPT_FUNC_THIS_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "int64 get_hash() const", FO_SCRIPT_FUNC_THIS(HashedString_GetHash), FO_SCRIPT_FUNC_THIS_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "uint64 get_uhash() const", FO_SCRIPT_FUNC_THIS(HashedString_GetUHash), FO_SCRIPT_FUNC_THIS_CONV));
     static constexpr hstring empty_hstring;
     FO_AS_VERIFY(as_engine->RegisterGlobalFunction("hstring get_EMPTY_HSTRING()", FO_SCRIPT_GENERIC(Global_GetZero<hstring>), FO_SCRIPT_GENERIC_CONV, cast_to_void(&empty_hstring)));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("string", "hstring hstr() const", FO_SCRIPT_GENERIC(String_ToHashedString), FO_SCRIPT_GENERIC_CONV));
@@ -739,20 +947,26 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "any& opAssign(const any &in)", FO_SCRIPT_FUNC_THIS(Any_Assign), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "bool opEquals(const any &in) const", FO_SCRIPT_FUNC_THIS(Type_Equals<any_t>), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "bool opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<bool>), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "int8 opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<int8>), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "uint8 opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<uint8>), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "int16 opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<int16>), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "uint16 opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<uint16>), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "int opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<int32>), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "uint opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<uint32>), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "int64 opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<int64>), FO_SCRIPT_FUNC_THIS_CONV));
-    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "uint64 opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<uint64>), FO_SCRIPT_FUNC_THIS_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "int8 opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<int8>), FO_SCRIPT_GENERIC_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "uint8 opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<uint8>), FO_SCRIPT_GENERIC_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "int16 opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<int16>), FO_SCRIPT_GENERIC_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "uint16 opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<uint16>), FO_SCRIPT_GENERIC_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "int opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<int32>), FO_SCRIPT_GENERIC_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "uint opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<uint32>), FO_SCRIPT_GENERIC_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "int64 opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<int64>), FO_SCRIPT_GENERIC_CONV));
+    FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "uint64 opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<uint64>), FO_SCRIPT_GENERIC_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "float opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<float32>), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "double opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<float64>), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "string opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_Conv<string>), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "hstring opImplConv() const", FO_SCRIPT_GENERIC(Any_ConvGen<hstring>), FO_SCRIPT_GENERIC_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("string", "any opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_ConvFrom<string>), FO_SCRIPT_FUNC_THIS_CONV));
     FO_AS_VERIFY(as_engine->RegisterObjectMethod("hstring", "any opImplConv() const", FO_SCRIPT_FUNC_THIS(Any_ConvFrom<hstring>), FO_SCRIPT_FUNC_THIS_CONV));
+
+    for (const auto& enum_name : meta->GetAllEnums() | std::views::keys) {
+        FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("any", AngelScript::asBEHAVE_CONSTRUCT, strex("void f({} value)", enum_name).c_str(), FO_SCRIPT_GENERIC(Any_ConstructFromEnum), FO_SCRIPT_GENERIC_CONV, cast_to_void(&enum_name)));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", strex("{} opImplConv() const", enum_name).c_str(), FO_SCRIPT_GENERIC(Any_ConvEnum), FO_SCRIPT_GENERIC_CONV, cast_to_void(&enum_name)));
+    }
+
     RegisterAngelScriptStringAnyExtensions(as_engine);
 
     // Built-in value types
@@ -883,7 +1097,7 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
         FO_AS_VERIFY(as_engine->RegisterObjectType(name, numeric_cast<int32>(type.Size), AngelScript::asOBJ_VALUE | AngelScript::asOBJ_POD | AngelScript::asOBJ_APP_CLASS_ALLINTS | AngelScript::asGetTypeTraits<SimpleClass>()));
     };
 
-    const auto register_generic_type_body = [&](const BaseTypeDesc& type) {
+    const auto register_metadata_type_common = [&](const BaseTypeDesc& type) {
         const char* name = type.Name.c_str();
         const auto& layout = *type.StructLayout;
 
@@ -899,18 +1113,21 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
         }
 
         FO_AS_VERIFY(as_engine->RegisterObjectBehaviour(name, AngelScript::asBEHAVE_CONSTRUCT, strex("void f({})", ctor_decl).c_str(), FO_SCRIPT_GENERIC(GenericType_ConstructArgs), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod(name, strex("bool opEquals(const {}&in other) const", name).c_str(), FO_SCRIPT_GENERIC(GenericType_Equals), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
+        FO_AS_VERIFY(as_engine->RegisterGlobalFunction(strex("{} get_ZERO_{}()", name, strex(name).upper()).c_str(), FO_SCRIPT_GENERIC(GenericType_GetZero), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
+    };
+
+    const auto register_generic_type_body = [&](const BaseTypeDesc& type) {
+        const char* name = type.Name.c_str();
+        register_metadata_type_common(type);
 
         if (type.IsSimpleStruct) {
             FO_AS_VERIFY(as_engine->RegisterObjectMethod(name, strex("int opCmp(const {}&in other) const", name).c_str(), FO_SCRIPT_GENERIC(GenericType_Cmp), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
         }
 
-        FO_AS_VERIFY(as_engine->RegisterObjectMethod(name, strex("bool opEquals(const {}&in other) const", name).c_str(), FO_SCRIPT_GENERIC(GenericType_Equals), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
-
         FO_AS_VERIFY(as_engine->RegisterObjectMethod(name, "string get_str() const", FO_SCRIPT_GENERIC(GenericType_GetStr), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod(name, "any opImplConv() const", FO_SCRIPT_GENERIC(GenericType_AnyConv), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
         FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", strex("{} opImplConv() const", name).c_str(), FO_SCRIPT_GENERIC(GenericType_AnyConvRev), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
-
-        FO_AS_VERIFY(as_engine->RegisterGlobalFunction(strex("{} get_ZERO_{}()", name, strex(name).upper()).c_str(), FO_SCRIPT_GENERIC(GenericType_GetZero), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
     };
 
     for (const auto& type : meta->GetBaseTypes() | std::views::values) {
@@ -919,6 +1136,54 @@ void RegisterAngelScriptTypes(AngelScript::asIScriptEngine* as_engine)
             register_generic_type(type);
         }
     }
+
+    // TextPackName
+    {
+        const auto& type = meta->GetBaseType("TextPackName");
+        registered_types.emplace(type.Name);
+        register_metadata_type_common(type);
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "int opCmp(const TextPackName&in other) const", FO_SCRIPT_FUNC_THIS(HstringWrapper_Cmp<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "string get_str() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "string opImplCast() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "string opImplConv() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "hstring opImplCast() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_HstringCast<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "hstring opImplConv() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_HstringCast<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackName", "any opImplConv() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_AnyConv<TextPackName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "TextPackName opImplConv() const", FO_SCRIPT_GENERIC(HstringWrapper_AnyConvRev<TextPackName>), FO_SCRIPT_GENERIC_CONV));
+    }
+
+    // LanguageName
+    {
+        const auto& type = meta->GetBaseType("LanguageName");
+        registered_types.emplace(type.Name);
+        register_metadata_type_common(type);
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "int opCmp(const LanguageName&in other) const", FO_SCRIPT_FUNC_THIS(HstringWrapper_Cmp<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "string get_str() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "string opImplCast() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "string opImplConv() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_StringCast<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "hstring opImplCast() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_HstringCast<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "hstring opImplConv() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_HstringCast<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("LanguageName", "any opImplConv() const", FO_SCRIPT_FUNC_THIS(HstringWrapper_AnyConv<LanguageName>), FO_SCRIPT_FUNC_THIS_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "LanguageName opImplConv() const", FO_SCRIPT_GENERIC(HstringWrapper_AnyConvRev<LanguageName>), FO_SCRIPT_GENERIC_CONV));
+    }
+
+    // TextPackKey
+    {
+        const auto& type = meta->GetBaseType("TextPackKey");
+        registered_types.emplace(type.Name);
+        register_metadata_type_common(type);
+        FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const string &in key1)", FO_SCRIPT_GENERIC(TextPackKey_Construct1), FO_SCRIPT_GENERIC_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const hstring &in key1)", FO_SCRIPT_GENERIC(TextPackKey_ConstructH1), FO_SCRIPT_GENERIC_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const string &in key1, const string &in key2)", FO_SCRIPT_GENERIC(TextPackKey_Construct2), FO_SCRIPT_GENERIC_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const hstring &in key1, const string &in key2)", FO_SCRIPT_GENERIC(TextPackKey_ConstructH2), FO_SCRIPT_GENERIC_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const string &in key1, const string &in key2, const string &in key3)", FO_SCRIPT_GENERIC(TextPackKey_Construct3), FO_SCRIPT_GENERIC_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectBehaviour("TextPackKey", AngelScript::asBEHAVE_CONSTRUCT, "void f(const TextPackName &in collection, const hstring &in key1, const string &in key2, const string &in key3)", FO_SCRIPT_GENERIC(TextPackKey_ConstructH3), FO_SCRIPT_GENERIC_CONV));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackKey", "int opCmp(const TextPackKey&in other) const", FO_SCRIPT_GENERIC(GenericType_Cmp), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackKey", "string get_str() const", FO_SCRIPT_GENERIC(GenericType_GetStr), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("TextPackKey", "any opImplConv() const", FO_SCRIPT_GENERIC(GenericType_AnyConv), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
+        FO_AS_VERIFY(as_engine->RegisterObjectMethod("any", "TextPackKey opImplConv() const", FO_SCRIPT_GENERIC(GenericType_AnyConvRev), FO_SCRIPT_GENERIC_CONV, cast_to_void(&type)));
+    }
+
     for (const auto& type : meta->GetBaseTypes() | std::views::values) {
         if (type.IsStruct && !registered_types.contains(type.Name)) {
             register_generic_type_body(type);

--- a/Source/Scripting/AngelScript/CoreScripts/Serializator.fos
+++ b/Source/Scripting/AngelScript/CoreScripts/Serializator.fos
@@ -259,12 +259,6 @@ class Serializator
         return Set(value.value);
     }
 
-    Serializator Set(const TextPackName& value)
-    {
-        int i = value;
-        return Set(i);
-    }
-
     Serializator Set(const any& value)
     {
         return Set(string(value));
@@ -622,14 +616,6 @@ class Serializator
     Serializator Get(ucolor& value)
     {
         Get(value.value);
-        return this;
-    }
-
-    Serializator Get(TextPackName& value)
-    {
-        int i = 0;
-        Get(i);
-        value = TextPackName(i);
         return this;
     }
 

--- a/Source/Scripting/ClientGlobalScriptMethods.cpp
+++ b/Source/Scripting/ClientGlobalScriptMethods.cpp
@@ -617,27 +617,27 @@ FO_SCRIPT_API void Client_Game_DrawVideoPlayback(ClientEngine* client, VideoPlay
 }
 
 ///@ ExportMethod
-FO_SCRIPT_API string Client_Game_GetText(ClientEngine* client, TextPackName textPack, uint32 strNum)
+FO_SCRIPT_API string Client_Game_GetText(ClientEngine* client, TextPackKey textKey)
 {
-    return client->GetCurLang().GetTextPack(textPack).GetStr(strNum);
+    return client->GetCurLang().GetText(textKey);
 }
 
 ///@ ExportMethod
-FO_SCRIPT_API string Client_Game_GetText(ClientEngine* client, TextPackName textPack, uint32 strNum, int32 skipCount)
+FO_SCRIPT_API string Client_Game_GetText(ClientEngine* client, TextPackKey textKey, int32 skipCount)
 {
-    return client->GetCurLang().GetTextPack(textPack).GetStr(strNum, skipCount);
+    return client->GetCurLang().GetText(textKey, numeric_cast<size_t>(skipCount));
 }
 
 ///@ ExportMethod
-FO_SCRIPT_API uint32 Client_Game_GetTextCount(ClientEngine* client, TextPackName textPack, uint32 strNum)
+FO_SCRIPT_API uint32 Client_Game_GetTextCount(ClientEngine* client, TextPackKey textKey)
 {
-    return numeric_cast<uint32>(client->GetCurLang().GetTextPack(textPack).GetStrCount(strNum));
+    return numeric_cast<uint32>(client->GetCurLang().GetTextCount(textKey));
 }
 
 ///@ ExportMethod
-FO_SCRIPT_API bool Client_Game_IsTextPresent(ClientEngine* client, TextPackName textPack, uint32 strNum)
+FO_SCRIPT_API bool Client_Game_IsTextPresent(ClientEngine* client, TextPackKey textKey)
 {
-    return client->GetCurLang().GetTextPack(textPack).GetStrCount(strNum) != 0;
+    return client->GetCurLang().IsTextPresent(textKey);
 }
 
 ///@ ExportMethod

--- a/Source/Scripting/CommonGlobalScriptMethods.cpp
+++ b/Source/Scripting/CommonGlobalScriptMethods.cpp
@@ -37,6 +37,7 @@
 #include "EngineBase.h"
 #include "Geometry.h"
 #include "ScriptSystem.h"
+#include "TextPack.h"
 
 FO_BEGIN_NAMESPACE
 
@@ -568,6 +569,12 @@ FO_SCRIPT_API uint32 Common_Game_StartTimeEvent(BaseEngine* engine, timespan del
 }
 
 ///@ ExportMethod
+FO_SCRIPT_API LanguageName Common_Game_GetLanguage(BaseEngine* engine)
+{
+    return LanguageName {engine->Hashes.ToHashedString(engine->Settings.Language)};
+}
+
+///@ ExportMethod
 FO_SCRIPT_API uint32 Common_Game_StartTimeEvent(BaseEngine* engine, timespan delay, timespan repeat, ScriptFunc<void> func)
 {
     return engine->TimeEventMngr.StartTimeEvent(engine, std::move(func), delay, repeat, {});
@@ -711,12 +718,6 @@ FO_SCRIPT_API void Common_Game_SetCurrentTimeEventData(BaseEngine* engine, reado
     if (auto&& [entity, te] = engine->TimeEventMngr.GetCurTimeEvent(); entity != nullptr) {
         engine->TimeEventMngr.ModifyTimeEvent(entity, {}, te->Id, std::nullopt, to_vector(data));
     }
-}
-
-///@ ExportMethod
-FO_SCRIPT_API int32 Common_Game_ResolveGenericValue(BaseEngine* engine, string_view str)
-{
-    return engine->ResolveGenericValue(str);
 }
 
 FO_END_NAMESPACE

--- a/Source/Scripting/ServerGlobalScriptMethods.cpp
+++ b/Source/Scripting/ServerGlobalScriptMethods.cpp
@@ -1202,9 +1202,9 @@ FO_SCRIPT_API vector<StaticItem*> Server_Game_GetStaticItemsForProtoMap(ServerEn
 }
 
 ///@ ExportMethod
-FO_SCRIPT_API bool Server_Game_IsTextPresent(ServerEngine* server, TextPackName textPack, uint32 strNum)
+FO_SCRIPT_API bool Server_Game_IsTextPresent(ServerEngine* server, TextPackKey textKey)
 {
-    return server->GetLangPack().GetTextPack(textPack).GetStrCount(strNum) != 0;
+    return server->GetLangPack().IsTextPresent(textKey);
 }
 
 static auto SystemCall(string_view command, const function<void(string_view)>& log_callback) -> int32

--- a/Source/Server/DataBase.cpp
+++ b/Source/Server/DataBase.cpp
@@ -163,8 +163,8 @@ DataBaseImpl::DataBaseImpl(DataBaseSettings& db_settings, DataBasePanicCallback 
     _settings {&db_settings},
     _opLogEnabled {_settings->OpLogEnabled},
     _pendingChangesPanicThreshold {numeric_cast<size_t>(_settings->PanicOpLogSizeThreshold)},
-    _reconnectRetryPeriod {std::chrono::milliseconds {std::max(_settings->ReconnectRetryPeriod, 1)}},
     _panicShutdownTimeout {std::chrono::milliseconds {_settings->PanicShutdownTimeout}},
+    _reconnectRetryPeriod {std::chrono::milliseconds {std::max(_settings->ReconnectRetryPeriod, 1)}},
     _panicCallback {std::move(panic_callback)}
 {
     FO_STACK_TRACE_ENTRY();
@@ -209,7 +209,6 @@ void DataBaseImpl::InitializeOpLogs()
             }
 
             const auto command = line.substr(0, first_space);
-            const auto collection = line.substr(first_space + 1, second_space - first_space - 1);
             string_view record_id_str {};
             string_view other {};
             bool has_other = false;
@@ -859,8 +858,7 @@ static auto DoesDocumentContain(const AnyData::Document& target, const AnyData::
         if (!target.Contains(patch_key)) {
             return false;
         }
-
-        if (!(target[patch_key] == patch_value)) {
+        if (target[patch_key] != patch_value) {
             return false;
         }
     }
@@ -1052,7 +1050,6 @@ auto DataBaseImpl::RecoveryLogHandle::Append(string_view text) noexcept -> bool
         }
 
         const auto command = line.substr(0, first_space);
-        const auto collection = line.substr(first_space + 1, second_space - first_space - 1);
         string_view record_id {};
         string_view other {};
         bool has_other = false;

--- a/Source/Server/Server.cpp
+++ b/Source/Server/Server.cpp
@@ -1280,34 +1280,18 @@ void ServerEngine::Process_Command(NetInBuffer& buf, const LogFunc& logcb, Playe
             break;
         }
 
-        const auto func_name_ = Hashes.ToHashedString(func_name);
-
-        bool failed = false;
-        const auto param0 = ResolveGenericValue(param0_str, &failed);
-        const auto param1 = ResolveGenericValue(param1_str, &failed);
-        const auto param2 = ResolveGenericValue(param2_str, &failed);
-
-        if (CallAdminFunc<void, Player*>(func_name_, player) || //
-            CallAdminFunc<void, Player*, int32>(func_name_, player, param0) || //
-            CallAdminFunc<void, Player*, any_t>(func_name_, player, param0_str) || //
-            CallAdminFunc<void, Player*, int32, int32>(func_name_, player, param0, param1) || //
-            CallAdminFunc<void, Player*, any_t, any_t>(func_name_, player, param0_str, param1_str) || //
-            CallAdminFunc<void, Player*, int32, int32, int32>(func_name_, player, param0, param1, param2) || //
-            CallAdminFunc<void, Player*, any_t, any_t, any_t>(func_name_, player, param0_str, param1_str, param2_str) || //
-            CallAdminFunc<void, Critter*>(func_name_, player_cr) || //
-            CallAdminFunc<void, Critter*, int32>(func_name_, player_cr, param0) || //
-            CallAdminFunc<void, Critter*, any_t>(func_name_, player_cr, param0_str) || //
-            CallAdminFunc<void, Critter*, int32, int32>(func_name_, player_cr, param0, param1) || //
-            CallAdminFunc<void, Critter*, any_t, any_t>(func_name_, player_cr, param0_str, param1_str) || //
-            CallAdminFunc<void, Critter*, int32, int32, int32>(func_name_, player_cr, param0, param1, param2) || //
-            CallAdminFunc<void, Critter*, any_t, any_t, any_t>(func_name_, player_cr, param0_str, param1_str, param2_str) || //
-            CallAdminFunc<void>(func_name_) || //
-            CallAdminFunc<void, int32>(func_name_, param0) || //
-            CallAdminFunc<void, any_t>(func_name_, param0_str) || //
-            CallAdminFunc<void, int32, int32>(func_name_, param0, param1) || //
-            CallAdminFunc<void, any_t, any_t>(func_name_, param0_str, param1_str) || //
-            CallAdminFunc<void, int32, int32, int32>(func_name_, param0, param1, param2) || //
-            CallAdminFunc<void, any_t, any_t, any_t>(func_name_, param0_str, param1_str, param2_str)) {
+        if (CallFunc<void, Player*>(Hashes.ToHashedString(func_name), player) || //
+            CallFunc<void, Player*, any_t>(Hashes.ToHashedString(func_name), player, param0_str) || //
+            CallFunc<void, Player*, any_t, any_t>(Hashes.ToHashedString(func_name), player, param0_str, param1_str) || //
+            CallFunc<void, Player*, any_t, any_t, any_t>(Hashes.ToHashedString(func_name), player, param0_str, param1_str, param2_str) || //
+            CallFunc<void, Critter*>(Hashes.ToHashedString(func_name), player_cr) || //
+            CallFunc<void, Critter*, any_t>(Hashes.ToHashedString(func_name), player_cr, param0_str) || //
+            CallFunc<void, Critter*, any_t, any_t>(Hashes.ToHashedString(func_name), player_cr, param0_str, param1_str) || //
+            CallFunc<void, Critter*, any_t, any_t, any_t>(Hashes.ToHashedString(func_name), player_cr, param0_str, param1_str, param2_str) || //
+            CallFunc<void>(Hashes.ToHashedString(func_name)) || //
+            CallFunc<void, any_t>(Hashes.ToHashedString(func_name), param0_str) || //
+            CallFunc<void, any_t, any_t>(Hashes.ToHashedString(func_name), param0_str, param1_str) || //
+            CallFunc<void, any_t, any_t, any_t>(Hashes.ToHashedString(func_name), param0_str, param1_str, param2_str)) {
             logcb("Run script success");
         }
         else {

--- a/Source/Server/Server.cpp
+++ b/Source/Server/Server.cpp
@@ -272,8 +272,8 @@ ServerEngine::ServerEngine(GlobalSettings& settings, FileSystem&& resources) :
 
         WriteLog("Load language data");
 
-        _defaultLang = LanguagePack {Settings.Language, *this};
-        _defaultLang.LoadFromResources(Resources);
+        _defaultLang = TextPack {Hashes};
+        _defaultLang.LoadFromResources(Resources, Settings.Language);
 
         return std::nullopt;
     });
@@ -314,7 +314,7 @@ ServerEngine::ServerEngine(GlobalSettings& settings, FileSystem&& resources) :
                 writer.Write<int16>(numeric_cast<int16>(file.GetPath().length()));
                 writer.WritePtr(file.GetPath().data(), file.GetPath().length());
                 writer.Write<uint32>(numeric_cast<uint32>(data.size()));
-                writer.Write<uint32>(Hashing::MurmurHash2(data.data(), data.size()));
+                writer.Write<uint32>(numeric_cast<uint32>(hashing_ex::hash(data.data(), data.size())));
             };
 
             for (const auto& resource_entry : Settings.ClientResourceEntries) {
@@ -1280,31 +1280,17 @@ void ServerEngine::Process_Command(NetInBuffer& buf, const LogFunc& logcb, Playe
             break;
         }
 
-        bool failed = false;
-        const auto param0 = ResolveGenericValue(param0_str, &failed);
-        const auto param1 = ResolveGenericValue(param1_str, &failed);
-        const auto param2 = ResolveGenericValue(param2_str, &failed);
-
         if (CallFunc<void, Player*>(Hashes.ToHashedString(func_name), player) || //
-            CallFunc<void, Player*, int32>(Hashes.ToHashedString(func_name), player, param0) || //
             CallFunc<void, Player*, any_t>(Hashes.ToHashedString(func_name), player, param0_str) || //
-            CallFunc<void, Player*, int32, int32>(Hashes.ToHashedString(func_name), player, param0, param1) || //
             CallFunc<void, Player*, any_t, any_t>(Hashes.ToHashedString(func_name), player, param0_str, param1_str) || //
-            CallFunc<void, Player*, int32, int32, int32>(Hashes.ToHashedString(func_name), player, param0, param1, param2) || //
             CallFunc<void, Player*, any_t, any_t, any_t>(Hashes.ToHashedString(func_name), player, param0_str, param1_str, param2_str) || //
             CallFunc<void, Critter*>(Hashes.ToHashedString(func_name), player_cr) || //
-            CallFunc<void, Critter*, int32>(Hashes.ToHashedString(func_name), player_cr, param0) || //
             CallFunc<void, Critter*, any_t>(Hashes.ToHashedString(func_name), player_cr, param0_str) || //
-            CallFunc<void, Critter*, int32, int32>(Hashes.ToHashedString(func_name), player_cr, param0, param1) || //
             CallFunc<void, Critter*, any_t, any_t>(Hashes.ToHashedString(func_name), player_cr, param0_str, param1_str) || //
-            CallFunc<void, Critter*, int32, int32, int32>(Hashes.ToHashedString(func_name), player_cr, param0, param1, param2) || //
             CallFunc<void, Critter*, any_t, any_t, any_t>(Hashes.ToHashedString(func_name), player_cr, param0_str, param1_str, param2_str) || //
             CallFunc<void>(Hashes.ToHashedString(func_name)) || //
-            CallFunc<void, int32>(Hashes.ToHashedString(func_name), param0) || //
             CallFunc<void, any_t>(Hashes.ToHashedString(func_name), param0_str) || //
-            CallFunc<void, int32, int32>(Hashes.ToHashedString(func_name), param0, param1) || //
             CallFunc<void, any_t, any_t>(Hashes.ToHashedString(func_name), param0_str, param1_str) || //
-            CallFunc<void, int32, int32, int32>(Hashes.ToHashedString(func_name), param0, param1, param2) || //
             CallFunc<void, any_t, any_t, any_t>(Hashes.ToHashedString(func_name), param0_str, param1_str, param2_str)) {
             logcb("Run script success");
         }
@@ -2856,7 +2842,7 @@ auto ServerEngine::MakePlayerId(string_view player_name) const -> ident_t
     FO_STACK_TRACE_ENTRY();
 
     FO_RUNTIME_ASSERT(!player_name.empty());
-    const auto hash_value = Hashing::MurmurHash2(reinterpret_cast<const uint8*>(player_name.data()), numeric_cast<uint32>(player_name.length()));
+    const auto hash_value = static_cast<uint32>(hashing_ex::hash(reinterpret_cast<const uint8*>(player_name.data()), player_name.length()));
     FO_RUNTIME_ASSERT(hash_value);
     return ident_t {(1u << 31u) | hash_value};
 }

--- a/Source/Server/Server.h
+++ b/Source/Server/Server.h
@@ -79,7 +79,7 @@ public:
     [[nodiscard]] auto IsStartingError() const noexcept -> bool { return _startingError; }
     [[nodiscard]] auto GetHealthInfo() const -> string;
     [[nodiscard]] auto MakePlayerId(string_view player_name) const -> ident_t;
-    [[nodiscard]] auto GetLangPack() const -> const LanguagePack& { return _defaultLang; }
+    [[nodiscard]] auto GetLangPack() const -> const TextPack& { return _defaultLang; }
 
     void Shutdown() override;
 
@@ -267,7 +267,7 @@ private:
     vector<uint8> _updateFilesDesc {};
     vector<refcount_ptr<Player>> _logClients {};
     vector<string> _logLines {};
-    LanguagePack _defaultLang {};
+    TextPack _defaultLang {Hashes};
     vector<unique_ptr<NetworkServer>> _connectionServers {}; // Todo: run network listeners dynamically, without restriction, based on server settings
     vector<refcount_ptr<Player>> _unloginedPlayers {};
     mutable std::mutex _unloginedPlayersLocker {};

--- a/Source/Tests/Test_CommonScriptMethods.cpp
+++ b/Source/Tests/Test_CommonScriptMethods.cpp
@@ -405,20 +405,6 @@ namespace CommonMethods
         return 0;
     }
 
-    // ========== ResolveGenericValue ==========
-
-    int TestResolveGenericValue()
-    {
-        // Resolve a numeric string
-        int val = Game.ResolveGenericValue("123");
-        if (val != 123) return -1;
-
-        int val2 = Game.ResolveGenericValue("0");
-        if (val2 != 0) return -2;
-
-        return 0;
-    }
-
  )" + R"(
     // ========== Entity Time Events (Critter) ==========
 
@@ -1088,18 +1074,6 @@ TEST_CASE("GameInvokeOperations")
     SECTION("ByNameWithData")
     {
         RUN_CM_FUNC("TestInvokeByNameWithData");
-    }
-}
-
-// ========== ResolveGenericValue ==========
-
-TEST_CASE("ResolveGenericValueOps")
-{
-    MAKE_CM_SERVER();
-
-    SECTION("ResolveGenericValue")
-    {
-        RUN_CM_FUNC("TestResolveGenericValue");
     }
 }
 

--- a/Source/Tests/Test_ConfigFile.cpp
+++ b/Source/Tests/Test_ConfigFile.cpp
@@ -55,17 +55,12 @@ static auto BuildConfigBenchmarkInput(int32 section_count, int32 keys_per_sectio
     return input;
 }
 
-static auto MakeBraceEntryKey(HashStorage& hashes, string_view base, string_view offset) -> string
-{
-    return strex("{}", hashes.ToHashedString(base).as_int32() + hashes.ToHashedString(offset).as_int32()).str();
-}
-
 TEST_CASE("ConfigFile")
 {
     SECTION("StoresViewsAndOwnedHookResults")
     {
         string source = "[ProtoItem]\n$Name = ItemOne\nName = Base\nName += Extra\n";
-        ConfigFile config {"Test.fomap", source, nullptr};
+        ConfigFile config {"Test.fomap", source};
 
         CHECK(config.HasSection("ProtoItem"));
         CHECK(config.GetAsStr("ProtoItem", "$Name") == "ItemOne");
@@ -79,7 +74,7 @@ TEST_CASE("ConfigFile")
 
     SECTION("PreservesViewsAfterMove")
     {
-        ConfigFile original {"Test.fomap", "[ProtoItem]\n$Name = One\nName = Value\n", nullptr};
+        ConfigFile original {"Test.fomap", "[ProtoItem]\n$Name = One\nName = Value\n"};
         ConfigFile moved {std::move(original)};
 
         CHECK(moved.HasSection("ProtoItem"));
@@ -89,8 +84,8 @@ TEST_CASE("ConfigFile")
 
     SECTION("PreservesViewsAfterMoveAssignment")
     {
-        ConfigFile source {"Test.fomap", "[ProtoItem]\n$Name = Assigned\nName = Payload\n", nullptr};
-        ConfigFile target {"Other.fomap", "[Other]\nValue = Legacy\n", nullptr};
+        ConfigFile source {"Test.fomap", "[ProtoItem]\n$Name = Assigned\nName = Payload\n"};
+        ConfigFile target {"Other.fomap", "[Other]\nValue = Legacy\n"};
 
         target = std::move(source);
 
@@ -102,7 +97,7 @@ TEST_CASE("ConfigFile")
     SECTION("CollectsSectionContent")
     {
         const string source = "[ShaderCommon]\nline_1 \\\nline_2\nvalue # keep content before comment stripping\n\n[VertexShader]\nvoid main() {}\n";
-        const ConfigFile config {"Effect.fofx", source, nullptr, ConfigFileOption::CollectContent};
+        const ConfigFile config {"Effect.fofx", source, ConfigFileOption::CollectContent};
 
         CHECK(config.GetSectionContent("ShaderCommon") == "line_1 line_2\nvalue # keep content before comment stripping\n");
         CHECK(config.GetSectionContent("VertexShader") == "void main() {}\n");
@@ -111,7 +106,7 @@ TEST_CASE("ConfigFile")
     SECTION("CollectsSectionContentForTabContinuedLines")
     {
         const string source = "[ShaderCommon]\nline_1\t\\\nline_2\n";
-        const ConfigFile config {"Effect.fofx", source, nullptr, ConfigFileOption::CollectContent};
+        const ConfigFile config {"Effect.fofx", source, ConfigFileOption::CollectContent};
 
         CHECK(config.GetSectionContent("ShaderCommon") == "line_1 line_2\n");
     }
@@ -119,7 +114,7 @@ TEST_CASE("ConfigFile")
     SECTION("ParsesCrLfLinesAndContinuation")
     {
         const string source = "[ShaderCommon]\r\nline_1 \\\r\nline_2\r\n[Section]\r\nKey = Value\r\n";
-        const ConfigFile config {"Effect.fofx", source, nullptr, ConfigFileOption::CollectContent};
+        const ConfigFile config {"Effect.fofx", source, ConfigFileOption::CollectContent};
 
         CHECK(config.GetSectionContent("ShaderCommon") == "line_1 line_2\n");
         CHECK(config.GetAsStr("Section", "Key") == "Value");
@@ -128,7 +123,7 @@ TEST_CASE("ConfigFile")
     SECTION("ParsesBoolIntsAndDefaults")
     {
         const string source = "[Section]\nEnabled = true\nDisabled = FALSE\nCount = 42\nName = Value\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK(config.GetNameHint() == "Test.cfg");
         CHECK(config.GetAsInt("Section", "Enabled") == 1);
@@ -146,7 +141,7 @@ TEST_CASE("ConfigFile")
     SECTION("TreatsFormFeedAndVerticalTabAsConfigWhitespace")
     {
         const string source = "[Section]\n\fCount\v=\f42\v\n\vEnabled\f=\vtrue\f\nText\f=\vValue\f\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK(config.GetAsInt("Section", "Count") == 42);
         CHECK(config.GetAsInt("Section", "Enabled") == 1);
@@ -156,7 +151,7 @@ TEST_CASE("ConfigFile")
     SECTION("PreservesEscapedCommentCharacters")
     {
         const string source = "[Section]\nText = keep\\#hash # strip this\nOther = value\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK(config.GetAsStr("Section", "Text") == "keep\\#hash");
         CHECK(config.GetAsStr("Section", "Other") == "value");
@@ -165,7 +160,7 @@ TEST_CASE("ConfigFile")
     SECTION("PreservesCommentCharactersInsideDoubleQuotes")
     {
         const string source = "[Section]\nText = \"quoted # hash\" # strip this\nOther = value\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK(config.GetAsStr("Section", "Text") == "\"quoted # hash\"");
         CHECK(config.GetAsStr("Section", "Other") == "value");
@@ -174,7 +169,7 @@ TEST_CASE("ConfigFile")
     SECTION("PreservesCommentCharactersInsideDoubleQuotesAcrossContinuedLines")
     {
         const string source = "[Section]\nText = \"quoted # hash\" \\\ncontinued # tail\nOther = value\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK(config.GetAsStr("Section", "Text") == "\"quoted # hash\" continued");
         CHECK(config.GetAsStr("Section", "Other") == "value");
@@ -183,7 +178,7 @@ TEST_CASE("ConfigFile")
     SECTION("PreservesCommentCharactersInsideQuotedAppendedValues")
     {
         const string source = "[Section]\nText = base\nText += \"quoted # hash\" # strip this\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK(config.GetAsStr("Section", "Text") == "base \"quoted # hash\"");
     }
@@ -191,42 +186,25 @@ TEST_CASE("ConfigFile")
     SECTION("PreservesCommentCharactersAfterEscapedQuotesInsideDoubleQuotes")
     {
         const string source = "[Section]\nText = \"quoted \\\" # hash\" # strip this\nOther = value\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK(config.GetAsStr("Section", "Text") == "\"quoted \\\" # hash\"");
         CHECK(config.GetAsStr("Section", "Other") == "value");
     }
 
-    SECTION("SupportsBraceFormatEntries")
+    SECTION("SkipsBraceFormatLines")
     {
-        const string source = "[Section]\n{100}{20}{Payload}\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
-
-        CHECK(config.GetAsStr("Section", "120") == "Payload");
-    }
-
-    SECTION("SupportsHashResolvedBraceFormatEntries")
-    {
-        HashStorage hashes;
-        const string source = "[Section]\n{BaseKey}{OffsetKey}{Payload}\n";
-        const ConfigFile config {"Test.cfg", source, &hashes};
-
-        CHECK(config.GetAsStr("Section", MakeBraceEntryKey(hashes, "BaseKey", "OffsetKey")) == "Payload");
-    }
-
-    SECTION("IgnoresIncompleteBraceFormatEntries")
-    {
-        const string source = "[Section]\n{100}{20\n{100}{20}\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const string source = "[Section]\n{100}{20}{Payload}\nKey = Value\n";
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK_FALSE(config.HasKey("Section", "120"));
-        CHECK(config.GetAsStr("Section", "120") == string_view {});
+        CHECK(config.GetAsStr("Section", "Key") == "Value");
     }
 
     SECTION("ReturnsRepeatedSections")
     {
         const string source = "[ProtoItem]\n$Name = One\n[ProtoItem]\n$Name = Two\n";
-        ConfigFile config {"Items.fopro", source, nullptr};
+        ConfigFile config {"Items.fopro", source};
         vector<map<string_view, string_view>*> sections = config.GetSections("ProtoItem");
 
         REQUIRE(sections.size() == 2);
@@ -237,7 +215,7 @@ TEST_CASE("ConfigFile")
     SECTION("ReturnsSectionViews")
     {
         string source = "[ProtoItem]\n$Name = One\nName = Base\nName += Two\n";
-        ConfigFile config {"Items.fopro", source, nullptr};
+        ConfigFile config {"Items.fopro", source};
         vector<map<string_view, string_view>*> sections = config.GetSections("ProtoItem");
 
         source.assign("broken");
@@ -249,28 +227,28 @@ TEST_CASE("ConfigFile")
 
     SECTION("GetSectionReturnsFirstRepeatedSection")
     {
-        ConfigFile config {"Items.fopro", "[ProtoItem]\n$Name = One\n[ProtoItem]\n$Name = Two\n", nullptr};
+        ConfigFile config {"Items.fopro", "[ProtoItem]\n$Name = One\n[ProtoItem]\n$Name = Two\n"};
 
         CHECK(config.GetSection("ProtoItem").at("$Name") == "One");
     }
 
     SECTION("AppendsIntoMissingKeyWithoutLeadingSpace")
     {
-        ConfigFile config {"Items.fopro", "[ProtoItem]\nName += Two\n", nullptr};
+        ConfigFile config {"Items.fopro", "[ProtoItem]\nName += Two\n"};
 
         CHECK(config.GetAsStr("ProtoItem", "Name") == "Two");
     }
 
     SECTION("IgnoresEmptyAppendedValueForExistingKey")
     {
-        ConfigFile config {"Items.fopro", "[ProtoItem]\nName = Base\nName +=    # ignored\n", nullptr};
+        ConfigFile config {"Items.fopro", "[ProtoItem]\nName = Base\nName +=    # ignored\n"};
 
         CHECK(config.GetAsStr("ProtoItem", "Name") == "Base");
     }
 
     SECTION("StopsAfterFirstSectionWhenRequested")
     {
-        ConfigFile config {"Items.fopro", "[ProtoItem]\n$Name = One\n[ProtoItem]\n$Name = Two\n", nullptr, ConfigFileOption::ReadFirstSection};
+        ConfigFile config {"Items.fopro", "[ProtoItem]\n$Name = One\n[ProtoItem]\n$Name = Two\n", ConfigFileOption::ReadFirstSection};
 
         CHECK(config.HasSection("ProtoItem"));
         CHECK(config.GetAsStr("ProtoItem", "$Name") == "One");
@@ -282,7 +260,7 @@ TEST_CASE("ConfigFile")
     {
         const auto options = static_cast<ConfigFileOption>(static_cast<uint8>(ConfigFileOption::CollectContent) | static_cast<uint8>(ConfigFileOption::ReadFirstSection));
 
-        ConfigFile config {"Effect.fofx", "[ShaderCommon]\nline_1 \\\nline_2\n[VertexShader]\nvoid main() {}\n", nullptr, options};
+        ConfigFile config {"Effect.fofx", "[ShaderCommon]\nline_1 \\\nline_2\n[VertexShader]\nvoid main() {}\n", options};
 
         CHECK(config.HasSection("ShaderCommon"));
         CHECK_FALSE(config.HasSection("VertexShader"));
@@ -293,7 +271,7 @@ TEST_CASE("ConfigFile")
 
     SECTION("ReturnsNullForMissingSectionKeyValues")
     {
-        ConfigFile config {"Items.fopro", "[ProtoItem]\n$Name = One\n", nullptr};
+        ConfigFile config {"Items.fopro", "[ProtoItem]\n$Name = One\n"};
 
         const auto* existing_section = config.GetSectionKeyValues("ProtoItem");
         const auto* missing_section = config.GetSectionKeyValues("Missing");
@@ -313,7 +291,7 @@ TEST_CASE("ConfigFile")
 
     SECTION("CollectsContentForRepeatedSections")
     {
-        ConfigFile config {"Effect.fofx", "[VertexShader]\nvoid main1() {}\n[VertexShader]\nvoid main2() {}\n", nullptr, ConfigFileOption::CollectContent};
+        ConfigFile config {"Effect.fofx", "[VertexShader]\nvoid main1() {}\n[VertexShader]\nvoid main2() {}\n", ConfigFileOption::CollectContent};
 
         vector<map<string_view, string_view>*> sections = config.GetSections("VertexShader");
 
@@ -324,7 +302,7 @@ TEST_CASE("ConfigFile")
 
     SECTION("ReturnsEmptyCollectedContentForMissingOrEmptySections")
     {
-        ConfigFile config {"Effect.fofx", "[Empty]\n[Filled]\nvalue\n", nullptr, ConfigFileOption::CollectContent};
+        ConfigFile config {"Effect.fofx", "[Empty]\n[Filled]\nvalue\n", ConfigFileOption::CollectContent};
 
         CHECK(config.GetSectionContent("Empty").empty());
         CHECK(config.GetSectionContent("Missing").empty());
@@ -334,7 +312,7 @@ TEST_CASE("ConfigFile")
     SECTION("IgnoresMalformedSectionsAndEntries")
     {
         const string source = "[]\nNoSeparator\n[ValidSection\n[Good]\nKey = Value\n";
-        const ConfigFile config {"Test.cfg", source, nullptr};
+        const ConfigFile config {"Test.cfg", source};
 
         CHECK_FALSE(config.HasSection("ValidSection"));
         CHECK(config.HasSection("Good"));
@@ -344,7 +322,7 @@ TEST_CASE("ConfigFile")
     SECTION("IgnoresEntriesWithEmptyTrimmedKeys")
     {
         const string source = "[Good]\n   = Ignored\n\t+= IgnoredToo\nKey = Value\n";
-        ConfigFile config {"Test.cfg", source, nullptr};
+        ConfigFile config {"Test.cfg", source};
         const auto* section = config.GetSectionKeyValues("Good");
 
         REQUIRE(section != nullptr);
@@ -357,7 +335,7 @@ TEST_CASE("ConfigFile")
 
     BENCHMARK("ParseLargeConfig")
     {
-        ConfigFile config {"Bench.fopro", benchmark_input, nullptr};
+        ConfigFile config {"Bench.fopro", benchmark_input};
         return numeric_cast<int32>(config.GetSections().size());
     };
 }

--- a/Source/Tests/Test_Containers.cpp
+++ b/Source/Tests/Test_Containers.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Containers")
 
     SECTION("StringHash")
     {
-        FO_HASH_NAMESPACE hash<string> hasher;
+        hashing::hash<string> hasher;
         CHECK(hasher(string {"hash-me"}) == hasher(string_view {"hash-me"}));
     }
 

--- a/Source/Tests/Test_EntityLifecycle.cpp
+++ b/Source/Tests/Test_EntityLifecycle.cpp
@@ -77,9 +77,8 @@ namespace EntityLifecycle
     }
 
     [[Event]]
-    bool OnInit()
+    void OnInit()
     {
-        return true;
     }
 
     [[Event]]

--- a/Source/Tests/Test_GenericUtils.cpp
+++ b/Source/Tests/Test_GenericUtils.cpp
@@ -39,22 +39,14 @@ FO_BEGIN_NAMESPACE
 
 TEST_CASE("GenericUtils")
 {
-    SECTION("MurmurHash2")
+    SECTION("WyHash")
     {
         const auto* data = reinterpret_cast<const uint8*>("abcdefg");
-        CHECK(Hashing::MurmurHash2(data, 4) == 646393889U);
-        CHECK(Hashing::MurmurHash2(data, 5) == 1594468574U);
-        CHECK(Hashing::MurmurHash2(data, 6) == 1271458169U);
-        CHECK(Hashing::MurmurHash2(data, 7) == 4188131059U);
-        CHECK(std::bit_cast<int32>(Hashing::MurmurHash2(data, 7)) == -106836237);
-        CHECK(Hashing::MurmurHash2_64(data, 6) == 13226566493390071673ULL);
-
-        CHECK(Hashing::MurmurHash2(nullptr, 0) == 0);
-        CHECK(Hashing::MurmurHash2_64(nullptr, 0) == 0);
-
         const auto* data2 = reinterpret_cast<const uint8*>("abcdefh");
-        CHECK(Hashing::MurmurHash2(data, 7) != Hashing::MurmurHash2(data2, 7));
-        CHECK(Hashing::MurmurHash2_64(data, 7) != Hashing::MurmurHash2_64(data2, 7));
+
+        CHECK(hashing_ex::hash(data, 4) != 0);
+        CHECK(hashing_ex::hash(data, 4) != hashing_ex::hash(data, 5));
+        CHECK(hashing_ex::hash(data, 7) != hashing_ex::hash(data2, 7));
     }
 
     SECTION("StdRandom")

--- a/Source/Tests/Test_HashedString.cpp
+++ b/Source/Tests/Test_HashedString.cpp
@@ -41,9 +41,6 @@ TEST_CASE("HashedString")
 {
     SECTION("EmptyHash")
     {
-        CHECK(Hashing::MurmurHash2(nullptr, 0) == 0);
-        CHECK(Hashing::MurmurHash2_64(nullptr, 0) == 0);
-
         const hstring empty {};
         CHECK_FALSE(static_cast<bool>(empty));
         CHECK(empty.as_hash() == 0);
@@ -52,11 +49,13 @@ TEST_CASE("HashedString")
 
     SECTION("StorageRoundtrip")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
         const auto hs = storage.ToHashedString("EssentialsTest");
         CHECK(static_cast<bool>(hs));
         CHECK(hs.as_hash() != 0);
+        CHECK(hs.as_uint64() == hs.as_hash());
+        CHECK(hs.as_hash() == hashing_ex::hash(hs.as_str().data(), hs.as_str().length()));
         CHECK(hs.as_str() == "EssentialsTest");
 
         const auto resolved = storage.ResolveHash(hs.as_hash());
@@ -66,7 +65,7 @@ TEST_CASE("HashedString")
 
     SECTION("IdempotentInsertion")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
         const auto hs1 = storage.ToHashedString("same_value");
         const auto hs2 = storage.ToHashedString("same_value");
@@ -78,10 +77,10 @@ TEST_CASE("HashedString")
 
     SECTION("ResolveHashNoThrow")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
         bool failed = false;
-        const auto unresolved_hash = Hashing::MurmurHash2("missing", 7);
+        const auto unresolved_hash = hashing_ex::hash("missing", 7);
         const auto unresolved = storage.ResolveHash(unresolved_hash, &failed);
 
         CHECK(failed);
@@ -90,7 +89,7 @@ TEST_CASE("HashedString")
 
     SECTION("ResolveHashNoThrowPreservesFailureOnSuccess")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
         const auto hs = storage.ToHashedString("known_value");
         bool failed = true;
@@ -103,24 +102,24 @@ TEST_CASE("HashedString")
 
     SECTION("ResolveHashThrows")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
         const auto hs = storage.ToHashedString("known");
         CHECK_NOTHROW(storage.ResolveHash(hs.as_hash()));
-        CHECK_THROWS_AS(storage.ResolveHash(Hashing::MurmurHash2("unknown", 7)), HashResolveException);
+        CHECK_THROWS_AS(storage.ResolveHash(hashing_ex::hash("unknown", 7)), HashResolveException);
     }
 
     SECTION("ResolveHashNoThrowNullFailed")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
-        const auto unresolved = storage.ResolveHash(Hashing::MurmurHash2("missing", 7), nullptr);
+        const auto unresolved = storage.ResolveHash(hashing_ex::hash("missing", 7), nullptr);
         CHECK_FALSE(static_cast<bool>(unresolved));
     }
 
     SECTION("ResolveHashNoThrowZeroHashPreservesFailure")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
         bool failed = true;
         const auto resolved = storage.ResolveHash(0, &failed);
@@ -131,12 +130,12 @@ TEST_CASE("HashedString")
 
     SECTION("ResolveHashNoThrowStickyFailureFlow")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
         const auto hs = storage.ToHashedString("known_flow");
         bool failed = false;
 
-        CHECK_FALSE(static_cast<bool>(storage.ResolveHash(Hashing::MurmurHash2("missing", 7), &failed)));
+        CHECK_FALSE(static_cast<bool>(storage.ResolveHash(hashing_ex::hash("missing", 7), &failed)));
         CHECK(failed);
 
         const auto resolved = storage.ResolveHash(hs.as_hash(), &failed);
@@ -150,7 +149,7 @@ TEST_CASE("HashedString")
 
     SECTION("EmptyStringToHashedString")
     {
-        HashStorage storage;
+        HashStorage storage {};
 
         const auto hs = storage.ToHashedString("");
         CHECK_FALSE(static_cast<bool>(hs));

--- a/Source/Tests/Test_MapLoader.cpp
+++ b/Source/Tests/Test_MapLoader.cpp
@@ -18,7 +18,7 @@ TEST_CASE("MapLoader")
     SECTION("RejectsOldMapFormat")
     {
         EngineMetadata meta {[] { }};
-        HashStorage hashes;
+        HashStorage hashes {};
 
         CHECK_THROWS_AS(MapLoader::Load("LegacyMap", "[Header]\n[Tiles]\n[Objects]\n", meta, hashes, [](ident_t, const ProtoCritter*, const map<string_view, string_view>&) { }, [](ident_t, const ProtoItem*, const map<string_view, string_view>&) { }), MapLoaderException);
     }
@@ -26,7 +26,7 @@ TEST_CASE("MapLoader")
     SECTION("RejectsMapsWithoutProtoMapSection")
     {
         EngineMetadata meta {[] { }};
-        HashStorage hashes;
+        HashStorage hashes {};
 
         CHECK_THROWS_AS(MapLoader::Load("BrokenMap", "[Critter]\n$Proto = CritterOne\n", meta, hashes, [](ident_t, const ProtoCritter*, const map<string_view, string_view>&) { }, [](ident_t, const ProtoItem*, const map<string_view, string_view>&) { }), MapLoaderException);
     }
@@ -34,7 +34,7 @@ TEST_CASE("MapLoader")
     SECTION("MissingProtosAccumulateErrorsAndSkipCallbacks")
     {
         EngineMetadata meta {[] { }};
-        HashStorage hashes;
+        HashStorage hashes {};
         size_t critter_calls = 0;
         size_t item_calls = 0;
 
@@ -56,7 +56,7 @@ TEST_CASE("MapLoader")
     SECTION("MissingProtoFieldAlsoFailsLoad")
     {
         EngineMetadata meta {[] { }};
-        HashStorage hashes;
+        HashStorage hashes {};
 
         const string map_buf = "[ProtoMap]\n"
                                "$Name = TestMap\n"
@@ -77,7 +77,7 @@ TEST_CASE("MapLoader")
         meta.RegisterProto(meta.Hashes.ToHashedString("Critter"), critter_proto);
         meta.RegisterProto(meta.Hashes.ToHashedString("Item"), item_proto);
 
-        HashStorage hashes;
+        HashStorage hashes {};
         vector<ident_t> critter_ids;
         vector<ident_t> item_ids;
         vector<string> critter_proto_names;

--- a/Source/Tests/Test_NetBuffer.cpp
+++ b/Source/Tests/Test_NetBuffer.cpp
@@ -128,7 +128,7 @@ TEST_CASE("NetBuffer")
 
     SECTION("HashedStringRoundtripSupportsDebugMode")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         const auto value = hashes.ToHashedString("net_hash_value");
 
         NetOutBuffer out_buf {8, true};

--- a/Source/Tests/Test_NetCommand.cpp
+++ b/Source/Tests/Test_NetCommand.cpp
@@ -9,7 +9,7 @@ TEST_CASE("NetCommand")
 {
     SECTION("UnknownCommandReturnsFalse")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
 
         const auto result = PackNetCommand("unknown 1 2 3", &out_buf, [](string_view) { }, hashes);
@@ -20,7 +20,7 @@ TEST_CASE("NetCommand")
 
     SECTION("ExitCommandSerializesWithoutArguments")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
 
         REQUIRE(PackNetCommand("exit", &out_buf, [](string_view) { }, hashes));
@@ -35,7 +35,7 @@ TEST_CASE("NetCommand")
 
     SECTION("MoveCommandSerializesCritterAndHex")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
 
         REQUIRE(PackNetCommand("move 42 17 23", &out_buf, [](string_view) { }, hashes));
@@ -53,7 +53,7 @@ TEST_CASE("NetCommand")
 
     SECTION("AliasesAndHashedPayloadAreSerialized")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
 
         REQUIRE(PackNetCommand("ais ammo_10mm 5", &out_buf, [](string_view) { }, hashes));
@@ -70,7 +70,7 @@ TEST_CASE("NetCommand")
 
     SECTION("AddNpcAndAddLocSerializeHashedProtos")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer npc_buf {8, true};
         NetOutBuffer loc_buf {8, true};
 
@@ -96,7 +96,7 @@ TEST_CASE("NetCommand")
 
     SECTION("PropertyCommandMarksSetValueAndTrimsWhitespace")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
 
         REQUIRE(PackNetCommand("prop 77 Health   150   ", &out_buf, [](string_view) { }, hashes));
@@ -115,7 +115,7 @@ TEST_CASE("NetCommand")
 
     SECTION("PropertyCommandWithoutValueMarksQuery")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
 
         REQUIRE(PackNetCommand("prop 88 Stamina", &out_buf, [](string_view) { }, hashes));
@@ -134,7 +134,7 @@ TEST_CASE("NetCommand")
 
     SECTION("RunAliasSerializesFunctionAndOptionalParameters")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
 
         REQUIRE(PackNetCommand("run module::Func alpha beta gamma", &out_buf, [](string_view) { }, hashes));
@@ -153,7 +153,7 @@ TEST_CASE("NetCommand")
 
     SECTION("LogCommandSerializesFlags")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
 
         REQUIRE(PackNetCommand("log --", &out_buf, [](string_view) { }, hashes));
@@ -169,7 +169,7 @@ TEST_CASE("NetCommand")
 
     SECTION("InvalidArgumentsLogAndDoNotWriteMessage")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         NetOutBuffer out_buf {8, true};
         string log_message;
 
@@ -181,7 +181,7 @@ TEST_CASE("NetCommand")
 
     SECTION("InvalidRunscriptAndLogArgumentsDoNotWriteMessage")
     {
-        HashStorage hashes;
+        HashStorage hashes {};
         string log_message;
 
         {

--- a/Source/Tests/Test_Properties.cpp
+++ b/Source/Tests/Test_Properties.cpp
@@ -339,16 +339,6 @@ namespace
             throw EnumResolveException("Enum name is not supported in test resolver");
         }
 
-        [[nodiscard]] auto ResolveGenericValue(string_view, bool* failed = nullptr) const -> int32 override
-        {
-            if (failed != nullptr) {
-                *failed = true;
-                return 0;
-            }
-
-            throw TypeResolveException("Generic values are not supported in test resolver");
-        }
-
         [[nodiscard]] auto CheckMigrationRule(hstring, hstring, hstring) const noexcept -> optional<hstring> override { return std::nullopt; }
         [[nodiscard]] auto GetProtoEntity(hstring type_name, hstring proto_id) const noexcept -> const ProtoEntity* override
         {
@@ -911,7 +901,7 @@ namespace
 
 TEST_CASE("PropertiesOverlay")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("TestEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1093,7 +1083,7 @@ TEST_CASE("PropertiesOverlay")
 
 TEST_CASE("PropertiesOverlayFiltersAndCopies")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("SyncEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1466,7 +1456,7 @@ TEST_CASE("PropertiesOverlayFiltersAndCopies")
 
 TEST_CASE("PropertiesFullStorageRoundTrip")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("FullEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1520,7 +1510,7 @@ TEST_CASE("PropertiesFullStorageRoundTrip")
 
 TEST_CASE("PropertiesFullStorageCopyFrom")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("FullCopyEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1550,7 +1540,7 @@ TEST_CASE("PropertiesFullStorageCopyFrom")
 
 TEST_CASE("PropertiesOverlayPreservesUnsyncedLocalOverridesOnRestore")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("ClientLocalEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1642,7 +1632,7 @@ TEST_CASE("PropertiesOverlayPreservesUnsyncedLocalOverridesOnRestore")
 
 TEST_CASE("PropertiesCompareData")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("CompareEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1744,7 +1734,7 @@ TEST_CASE("PropertiesCompareData")
 
 TEST_CASE("PropertiesCustomAccessors")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("AccessorEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1851,7 +1841,7 @@ TEST_CASE("PropertyRawDataStorageModes")
 
 TEST_CASE("PropertiesTextRoundTrip")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("TextEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1875,7 +1865,7 @@ TEST_CASE("PropertiesTextRoundTrip")
 
 TEST_CASE("PropertiesHashAndEnumConversions")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("TypedEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1909,7 +1899,7 @@ TEST_CASE("PropertiesHashAndEnumConversions")
 
 TEST_CASE("PropertiesNumericWidthConversions")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("NumericWidthsEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -1958,7 +1948,7 @@ TEST_CASE("PropertiesNumericWidthConversions")
 
 TEST_CASE("PropertiesTextScalarWidthConversions")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("NumericTextWidthsEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2021,7 +2011,7 @@ TEST_CASE("PropertiesTextScalarWidthConversions")
 
 TEST_CASE("PropertiesPrimitiveDictKeyTextConversions")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("PrimitiveDictKeyEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2090,7 +2080,7 @@ TEST_CASE("PropertiesPrimitiveDictKeyTextConversions")
 
 TEST_CASE("PropertiesBuiltinProtoReferenceSupport")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("ProtoTypedEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2155,7 +2145,7 @@ TEST_CASE("PropertiesBuiltinProtoReferenceSupport")
 
 TEST_CASE("PropertiesSerializatorRejectsInvalidTypedInputs")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("InvalidTypedEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2215,7 +2205,7 @@ TEST_CASE("PropertiesSerializatorRejectsInvalidTypedInputs")
 
 TEST_CASE("PropertiesStoreAllDataAccumulatesHashesAcrossObjects")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("AccumulatedHashesEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2241,7 +2231,7 @@ TEST_CASE("PropertiesStoreAllDataAccumulatesHashesAcrossObjects")
 
 TEST_CASE("PropertiesDictConversions")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DictEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2308,7 +2298,7 @@ TEST_CASE("PropertiesDictConversions")
 
 TEST_CASE("PropertiesNumericDictConversions")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("NumericDictEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2364,7 +2354,7 @@ TEST_CASE("PropertiesNumericDictConversions")
 
 TEST_CASE("PropertiesSpecialValueDictArrays")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("SpecialDictEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2426,7 +2416,7 @@ TEST_CASE("PropertiesSpecialValueDictArrays")
 
 TEST_CASE("PropertiesFloatDictConversions")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("FloatDictEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2481,7 +2471,7 @@ TEST_CASE("PropertiesFloatDictConversions")
 
 TEST_CASE("PropertiesStructDictConversions")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("StructDictEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2563,7 +2553,7 @@ TEST_CASE("PropertiesStructDictConversions")
 
 TEST_CASE("PropertiesSerializatorRejectsInvalidStructShapes")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("InvalidStructEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2596,7 +2586,7 @@ TEST_CASE("PropertiesSerializatorRejectsInvalidStructShapes")
 
 TEST_CASE("PropertiesSerializatorRejectsInvalidTextStructShapes")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("InvalidTextStructEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2613,7 +2603,7 @@ TEST_CASE("PropertiesSerializatorRejectsInvalidTextStructShapes")
 
 TEST_CASE("PropertiesSaveToDocumentSkipsDefaultAndBaseValues")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2644,7 +2634,7 @@ TEST_CASE("PropertiesSaveToDocumentSkipsDefaultAndBaseValues")
 
 TEST_CASE("PropertiesLoadFromDocumentSkipsTechnicalAndUnknownFields")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentLoadEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2666,7 +2656,7 @@ TEST_CASE("PropertiesLoadFromDocumentSkipsTechnicalAndUnknownFields")
 
 TEST_CASE("PropertiesLoadFromDocumentReportsInvalidFieldButContinues")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentErrorEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2685,7 +2675,7 @@ TEST_CASE("PropertiesLoadFromDocumentReportsInvalidFieldButContinues")
 
 TEST_CASE("PropertiesLoadFromDocumentRejectsUnsupportedAnyDataValueTypes")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentTypeErrorEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2707,7 +2697,7 @@ TEST_CASE("PropertiesLoadFromDocumentRejectsUnsupportedAnyDataValueTypes")
 
 TEST_CASE("PropertiesLoadFromDocumentRejectsInvalidHashValueTypes")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentHashTypeErrorEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2729,7 +2719,7 @@ TEST_CASE("PropertiesLoadFromDocumentRejectsInvalidHashValueTypes")
 
 TEST_CASE("PropertiesLoadFromDocumentRejectsWrongCollectionValueTypes")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentCollectionTypeErrorEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2751,7 +2741,7 @@ TEST_CASE("PropertiesLoadFromDocumentRejectsWrongCollectionValueTypes")
 
 TEST_CASE("PropertiesLoadFromDocumentRejectsWrongDictArrayValueTypes")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentDictArrayTypeErrorEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2773,7 +2763,7 @@ TEST_CASE("PropertiesLoadFromDocumentRejectsWrongDictArrayValueTypes")
 
 TEST_CASE("PropertiesLoadFromDocumentRejectsInvalidInnerStringCollectionValues")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentStringCollectionInnerTypeErrorEntity", EngineSideKind::ServerSide, hashes, resolver);
 
@@ -2801,7 +2791,7 @@ TEST_CASE("PropertiesLoadFromDocumentRejectsInvalidInnerStringCollectionValues")
 
 TEST_CASE("PropertiesLoadFromDocumentRejectsInvalidInnerDictArrayStringValues")
 {
-    HashStorage hashes;
+    HashStorage hashes {};
     TestNameResolver resolver;
     PropertyRegistrator registrator("DocumentDictArrayStringInnerTypeErrorEntity", EngineSideKind::ServerSide, hashes, resolver);
 

--- a/Source/Tests/Test_RemoteCallValidation.cpp
+++ b/Source/Tests/Test_RemoteCallValidation.cpp
@@ -154,7 +154,7 @@ TEST_CASE("RemoteCallValidation")
         const RemoteCallDesc call = MakeRemoteCall(meta, {MakeSimpleArg(hstring_type)});
         vector<uint8> data;
         DataWriter writer(data);
-        const hstring::hash_t unknown_hash = Hashing::MurmurHash2("MissingHash", 11);
+        const hstring::hash_t unknown_hash = hashing_ex::hash("MissingHash", 11);
 
         writer.Write<hstring::hash_t>(unknown_hash);
 

--- a/Source/Tests/Test_ScriptBuiltins.cpp
+++ b/Source/Tests/Test_ScriptBuiltins.cpp
@@ -167,6 +167,47 @@ namespace ScriptBuiltins
         return s.trim();
     }
 
+    string EnumToAnyString()
+    {
+        any value = GenderType::Male;
+        string stored = value;
+        return stored;
+    }
+
+    string EnumAssignToAnyString()
+    {
+        any value;
+        value = GenderType::Female;
+        string stored = value;
+        return stored;
+    }
+
+    bool EnumRoundtripFromAny()
+    {
+        any value = GenderType::Male;
+        GenderType parsed = value;
+        return parsed == GenderType::Male;
+    }
+
+    bool EnumParseFullNameFromAny()
+    {
+        any value = "GenderType::Female";
+        GenderType parsed = value;
+        return parsed == GenderType::Female;
+    }
+
+    void InvalidIntConversionFromAny()
+    {
+        any value = "DefinitelyNotANumber";
+        int parsed = value;
+    }
+
+    int EmptyAnyToInt()
+    {
+        any value;
+        return int(value);
+    }
+
     // === Array operations ===
 
     int ArrayLength(int[] arr)
@@ -529,9 +570,39 @@ namespace ScriptBuiltins
             });
     }
 
+    static auto MakeMetadataWithGenderEnum() -> vector<uint8>
+    {
+        vector<uint8> metadata;
+        auto writer = DataWriter(metadata);
+
+        writer.Write<uint16>(uint16 {1}); // 1 section
+
+        const string_view section_name = "Enum";
+        writer.Write<uint16>(numeric_cast<uint16>(section_name.size()));
+        writer.WritePtr(section_name.data(), section_name.size());
+        writer.Write<uint32>(uint32 {1}); // 1 entry
+
+        // GenderType int Male 0 Female 1
+        writer.Write<uint32>(uint32 {6}); // 6 tokens
+
+        auto write_token = [&](string_view token) {
+            writer.Write<uint16>(numeric_cast<uint16>(token.size()));
+            writer.WritePtr(token.data(), token.size());
+        };
+
+        write_token("GenderType");
+        write_token("uint8");
+        write_token("Male");
+        write_token("0");
+        write_token("Female");
+        write_token("1");
+
+        return metadata;
+    }
+
     static auto MakeResources() -> FileSystem
     {
-        const auto metadata_blob = BakerTests::MakeEmptyMetadataBlob();
+        const auto metadata_blob = MakeMetadataWithGenderEnum();
 
         auto compiler_resources_source = SafeAlloc::MakeUnique<BakerTests::MemoryDataSource>("ScriptBuiltinsCompilerResources");
         compiler_resources_source->AddFile("Metadata.fometa-server", metadata_blob);
@@ -708,6 +779,65 @@ TEST_CASE("ScriptBuiltinsStringOperations")
         REQUIRE(func);
         REQUIRE(func.Call());
         CHECK(func.GetResult() == 1);
+    }
+
+    // Enum <-> any conversions store full enum names
+    {
+        auto func = server->FindFunc<string>(fn("ScriptBuiltins::EnumToAnyString"));
+        REQUIRE(func);
+        REQUIRE(func.Call());
+        CHECK(func.GetResult() == "GenderType::Male");
+    }
+
+    {
+        auto func = server->FindFunc<string>(fn("ScriptBuiltins::EnumAssignToAnyString"));
+        REQUIRE(func);
+        REQUIRE(func.Call());
+        CHECK(func.GetResult() == "GenderType::Female");
+    }
+
+    {
+        auto func = server->FindFunc<bool>(fn("ScriptBuiltins::EnumRoundtripFromAny"));
+        REQUIRE(func);
+        REQUIRE(func.Call());
+        CHECK(func.GetResult() == true);
+    }
+
+    {
+        auto func = server->FindFunc<bool>(fn("ScriptBuiltins::EnumParseFullNameFromAny"));
+        REQUIRE(func);
+        REQUIRE(func.Call());
+        CHECK(func.GetResult() == true);
+    }
+
+    {
+        auto func = server->FindFunc<void>(fn("ScriptBuiltins::InvalidIntConversionFromAny"));
+        REQUIRE(func);
+
+        const auto prev_callback = GetExceptionCallback();
+        string message;
+        string traceback;
+        bool fatal = true;
+        SetExceptionCallback([&](string_view msg, string_view trace, bool is_fatal) {
+            message = string(msg);
+            traceback = string(trace);
+            fatal = is_fatal;
+        });
+        auto restore_callback = scope_exit([prev = std::move(prev_callback)]() mutable noexcept { SetExceptionCallback(std::move(prev)); });
+
+        CHECK_FALSE(func.Call());
+        CHECK(message.find("Invalid int value for any conversion") != string::npos);
+        CHECK(message.find("DefinitelyNotANumber") != string::npos);
+        CHECK_FALSE(traceback.empty());
+        CHECK_FALSE(fatal);
+    }
+
+    // Empty any → int must return 0
+    {
+        auto func = server->FindFunc<int32>(fn("ScriptBuiltins::EmptyAnyToInt"));
+        REQUIRE(func);
+        REQUIRE(func.Call());
+        CHECK(func.GetResult() == 0);
     }
 }
 

--- a/Source/Tests/Test_ServerEngine.cpp
+++ b/Source/Tests/Test_ServerEngine.cpp
@@ -88,10 +88,9 @@ namespace ServerEngineTest
     }
 
     [[Event]]
-    bool OnInit()
+    void OnInit()
     {
         InitCalls++;
-        return true;
     }
 
     [[Event]]

--- a/Source/Tests/Test_ServerItems.cpp
+++ b/Source/Tests/Test_ServerItems.cpp
@@ -74,9 +74,8 @@ namespace ServerItemsTest
     }
 
     [[Event]]
-    bool OnInit()
+    void OnInit()
     {
-        return true;
     }
 
     [[Event]]

--- a/Source/Tests/Test_ServerScriptMethods.cpp
+++ b/Source/Tests/Test_ServerScriptMethods.cpp
@@ -587,9 +587,7 @@ namespace ScriptMethodsTest
     int TestTextPresent()
     {
         // Just calling the method exercises the code path
-        // TextPackName might not be available, but the call itself is the coverage goal
-        // Using known-invalid values still exercises error handling
-        bool present = Game.IsTextPresent(TextPackName::None, 0);
+        bool present = Game.IsTextPresent(TextPackKey());
         return 0;
     }
 

--- a/Source/Tests/Test_Settings.cpp
+++ b/Source/Tests/Test_Settings.cpp
@@ -44,8 +44,7 @@ TEST_CASE("Settings")
             "[ResourcePack]\n"
             "Name = ServerPack\n"
             "InputDirs = server_dir\n"
-            "ServerOnly = true\n",
-            nullptr};
+            "ServerOnly = true\n"};
 
         settings.ApplyConfigFile(config, "cfg");
 
@@ -120,7 +119,7 @@ TEST_CASE("Settings")
     SECTION("BakingModeSaveReturnsAppliedSettings")
     {
         GlobalSettings settings {true};
-        ConfigFile config {"Bake.fomain", "CustomSaved = value\n", nullptr};
+        ConfigFile config {"Bake.fomain", "CustomSaved = value\n"};
 
         settings.ApplyConfigFile(config, "");
 

--- a/Source/Tests/Test_TextPack.cpp
+++ b/Source/Tests/Test_TextPack.cpp
@@ -32,150 +32,211 @@
 
 #include "catch_amalgamated.hpp"
 
+#include "HashedString.h"
 #include "TextPack.h"
 
 FO_BEGIN_NAMESPACE
 
+namespace
+{
+    HashStorage TestHashes;
+
+    auto MakeKey(string_view collection, string_view key1, string_view key2 = {}) -> TextPackKey
+    {
+        return TextPackKey::FromParts(TestHashes, collection, key1, key2);
+    }
+
+    auto FormatKey(const TextPackKey& key) -> string
+    {
+        return strex("{}", key).str();
+    }
+}
+
 TEST_CASE("TextPack")
 {
-    SECTION("LoadFromStringParsesNumericOffsetsAndMultilineValues")
+    SECTION("TextPackKeyFormatsAndParsesStructuredTuple")
     {
-        HashStorage hashes;
-        TextPack pack;
+        const auto key = TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Name", "Short");
+        CHECK(FormatKey(key) == "{Items}{LaserRifle}{Name}{Short}");
+
+        TextPackKey parsed;
+        REQUIRE(TextPackKey::Parse(TestHashes, FormatKey(key), parsed));
+        CHECK(parsed == key);
+    }
+
+    SECTION("LoadFromStringParsesKeysAndMultilineValues")
+    {
+        TextPack pack(TestHashes);
 
         const string input = "{100}{}{Hello}\n{200}{3}{World}\n{300}{}{Line1\nLine2}";
 
-        REQUIRE(pack.LoadFromString(input, hashes));
+        REQUIRE(pack.LoadFromString(input, "Dialogs"));
         CHECK(pack.GetSize() == 3);
-        CHECK(pack.GetStr(100, 0) == "Hello");
-        CHECK(pack.GetStr(203, 0) == "World");
-        CHECK(pack.GetStr(300, 0) == "Line1\nLine2");
-        CHECK(pack.GetStrCount(300) == 1);
-        CHECK(pack.GetStr(9999).empty());
+        CHECK(pack.GetStr(MakeKey("Dialogs", "100"), 0) == "Hello");
+        CHECK(pack.GetStr(MakeKey("Dialogs", "200", "3"), 0) == "World");
+        CHECK(pack.GetStr(MakeKey("Dialogs", "300"), 0) == "Line1\nLine2");
+        CHECK(pack.GetStrCount(MakeKey("Dialogs", "300")) == 1);
+        CHECK(pack.GetStr(MakeKey("Dialogs", "9999")).empty());
     }
 
-    SECTION("LoadFromStringSupportsHashedKeysAndOffsets")
+    SECTION("LoadFromStringSupportsNamedKeysAndOffsets")
     {
-        HashStorage hashes;
-        TextPack pack;
+        TextPack pack(TestHashes);
 
-        const auto base_hash = hashes.ToHashedString("QuestEntry").as_int32();
-        const auto offset_hash = hashes.ToHashedString("Suffix").as_int32();
         const string input = "{QuestEntry}{}{Base}\n{QuestEntry}{Suffix}{Combined}";
 
-        REQUIRE(pack.LoadFromString(input, hashes));
-        CHECK(pack.GetStr(base_hash, 0) == "Base");
-        CHECK(pack.GetStr(base_hash + offset_hash, 0) == "Combined");
+        REQUIRE(pack.LoadFromString(input, "Quest"));
+        CHECK(pack.GetStr(MakeKey("Quest", "QuestEntry"), 0) == "Base");
+        CHECK(pack.GetStr(MakeKey("Quest", "QuestEntry", "Suffix"), 0) == "Combined");
+    }
+
+    SECTION("LoadFromStringParsesStructuredTupleKeys")
+    {
+        TextPack pack(TestHashes);
+
+        const auto key = TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Name");
+        const string input = "{LaserRifle}{Name}{Scoped energy rifle}";
+
+        REQUIRE(pack.LoadFromString(input, "Items"));
+        CHECK(pack.GetStr(key, 0) == "Scoped energy rifle");
+        CHECK(pack.GetStrCount(key) == 1);
     }
 
     SECTION("BinaryRoundtripPreservesEntries")
     {
-        TextPack pack;
-        pack.AddStr(10, string_view {"Alpha"});
-        pack.AddStr(20, string_view {"Beta"});
-        pack.AddStr(20, string_view {"Gamma"});
+        TextPack pack(TestHashes);
+        const auto structured_key = TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Name");
+        const auto dialogs_ten = MakeKey("Dialogs", "10");
+        const auto dialogs_twenty = MakeKey("Dialogs", "20");
+
+        pack.AddStr(structured_key, string_view {"Laser Rifle"});
+        pack.AddStr(dialogs_ten, string_view {"Alpha"});
+        pack.AddStr(dialogs_twenty, string_view {"Beta"});
+        pack.AddStr(dialogs_twenty, string_view {"Gamma"});
 
         const auto data = pack.GetBinaryData();
 
-        TextPack restored;
+        TextPack restored(TestHashes);
         REQUIRE(restored.LoadFromBinaryData(data));
-        CHECK(restored.GetSize() == 3);
-        CHECK(restored.GetStrCount(10) == 1);
-        CHECK(restored.GetStrCount(20) == 2);
-        CHECK(restored.GetStr(10, 0) == "Alpha");
-        CHECK(restored.GetStr(20, 0) == "Beta");
-        CHECK(restored.GetStr(20, 1) == "Gamma");
+        CHECK(restored.GetSize() == 4);
+        CHECK(restored.GetStr(structured_key, 0) == "Laser Rifle");
+        CHECK(restored.GetStrCount(structured_key) == 1);
+        CHECK(restored.GetStrCount(dialogs_ten) == 1);
+        CHECK(restored.GetStrCount(dialogs_twenty) == 2);
+        CHECK(restored.GetStr(dialogs_ten, 0) == "Alpha");
+        CHECK(restored.GetStr(dialogs_twenty, 0) == "Beta");
+        CHECK(restored.GetStr(dialogs_twenty, 1) == "Gamma");
     }
 
     SECTION("FixStrAddsMissingAndRemovesUnknownKeys")
     {
-        TextPack base_pack;
-        base_pack.AddStr(1, string_view {"BaseOne"});
-        base_pack.AddStr(2, string_view {"BaseTwo"});
+        TextPack base_pack(TestHashes);
+        base_pack.AddStr(MakeKey("Dialogs", "1"), string_view {"BaseOne"});
+        base_pack.AddStr(MakeKey("Dialogs", "2"), string_view {"BaseTwo"});
 
-        TextPack localized_pack;
-        localized_pack.AddStr(2, string_view {"LocalizedTwo"});
-        localized_pack.AddStr(3, string_view {"Unexpected"});
+        TextPack localized_pack(TestHashes);
+        localized_pack.AddStr(MakeKey("Dialogs", "2"), string_view {"LocalizedTwo"});
+        localized_pack.AddStr(MakeKey("Dialogs", "3"), string_view {"Unexpected"});
 
         localized_pack.FixStr(base_pack);
 
         CHECK(localized_pack.GetSize() == 2);
-        CHECK(localized_pack.GetStr(1, 0) == "BaseOne");
-        CHECK(localized_pack.GetStr(2, 0) == "LocalizedTwo");
-        CHECK(localized_pack.GetStr(3).empty());
+        CHECK(localized_pack.GetStr(MakeKey("Dialogs", "1"), 0) == "BaseOne");
+        CHECK(localized_pack.GetStr(MakeKey("Dialogs", "2"), 0) == "LocalizedTwo");
+        CHECK(localized_pack.GetStr(MakeKey("Dialogs", "3")).empty());
+    }
+
+    SECTION("FixStrMatchesStructuredKeysDirectly")
+    {
+        TextPack base_pack(TestHashes);
+        base_pack.AddStr(TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Name"), string_view {"Laser Rifle"});
+        base_pack.AddStr(TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Desc"), string_view {"Base description"});
+
+        TextPack localized_pack(TestHashes);
+        localized_pack.AddStr(TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Name"), string_view {"Лазерная винтовка"});
+        localized_pack.AddStr(TextPackKey::FromParts(TestHashes, "Items", "Unused", "Desc"), string_view {"Лишнее"});
+
+        localized_pack.FixStr(base_pack);
+
+        CHECK(localized_pack.GetStr(TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Name"), 0) == "Лазерная винтовка");
+        CHECK(localized_pack.GetStr(TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Desc"), 0) == "Base description");
+        CHECK(localized_pack.GetStr(TextPackKey::FromParts(TestHashes, "Items", "Unused", "Desc")).empty());
     }
 
     SECTION("LoadFromMapAndClearWorkTogether")
     {
-        TextPack pack;
-        const map<string, string> entries {{"7", "Seven"}, {"0", "Ignored"}, {"11", "Eleven"}};
+        TextPack pack(TestHashes);
+        const auto structured_key = TextPackKey::FromParts(TestHashes, "Items", "LaserRifle", "Desc");
+        const map<string, string> entries {{"7", "Seven"}, {"11", "Eleven"}, {FormatKey(structured_key), "Description"}};
 
-        pack.LoadFromMap(entries);
+        pack.LoadFromMap(entries, "Dialogs");
 
-        CHECK(pack.GetSize() == 2);
-        CHECK(pack.GetStr(7, 0) == "Seven");
-        CHECK(pack.GetStr(11, 0) == "Eleven");
+        CHECK(pack.GetSize() == 3);
+        CHECK(pack.GetStr(MakeKey("Dialogs", "7"), 0) == "Seven");
+        CHECK(pack.GetStr(MakeKey("Dialogs", "11"), 0) == "Eleven");
+        CHECK(pack.GetStr(structured_key, 0) == "Description");
 
         pack.Clear();
 
         CHECK(pack.GetSize() == 0);
-        CHECK(pack.GetStr(7).empty());
+        CHECK(pack.GetStr(MakeKey("Dialogs", "7")).empty());
+        CHECK(pack.GetStr(structured_key).empty());
     }
 
     SECTION("MergeEraseAndIntersectionTrackSharedKeys")
     {
-        TextPack base_pack;
-        base_pack.AddStr(1, string_view {"BaseOne"});
-        base_pack.AddStr(2, string_view {"BaseTwo"});
+        TextPack base_pack(TestHashes);
+        base_pack.AddStr(MakeKey("Dialogs", "1"), string_view {"BaseOne"});
+        base_pack.AddStr(MakeKey("Dialogs", "2"), string_view {"BaseTwo"});
 
-        TextPack incoming_pack;
-        incoming_pack.AddStr(2, string_view {"IncomingTwo"});
-        incoming_pack.AddStr(3, string_view {"IncomingThree"});
+        TextPack incoming_pack(TestHashes);
+        incoming_pack.AddStr(MakeKey("Dialogs", "2"), string_view {"IncomingTwo"});
+        incoming_pack.AddStr(MakeKey("Dialogs", "3"), string_view {"IncomingThree"});
 
         CHECK(base_pack.CheckIntersections(incoming_pack));
 
         base_pack.Merge(incoming_pack);
 
         CHECK(base_pack.GetSize() == 4);
-        CHECK(base_pack.GetStrCount(2) == 2);
-        CHECK(base_pack.GetStr(2, 0) == "BaseTwo");
-        CHECK(base_pack.GetStr(2, 1) == "IncomingTwo");
-        CHECK(base_pack.GetStr(3, 0) == "IncomingThree");
+        CHECK(base_pack.GetStrCount(MakeKey("Dialogs", "2")) == 2);
+        CHECK(base_pack.GetStr(MakeKey("Dialogs", "2"), 0) == "BaseTwo");
+        CHECK(base_pack.GetStr(MakeKey("Dialogs", "2"), 1) == "IncomingTwo");
+        CHECK(base_pack.GetStr(MakeKey("Dialogs", "3"), 0) == "IncomingThree");
 
-        base_pack.EraseStr(2);
+        base_pack.EraseStr(MakeKey("Dialogs", "2"));
 
-        CHECK(base_pack.GetStrCount(2) == 0);
-        CHECK(base_pack.GetStr(2).empty());
+        CHECK(base_pack.GetStrCount(MakeKey("Dialogs", "2")) == 0);
+        CHECK(base_pack.GetStr(MakeKey("Dialogs", "2")).empty());
         CHECK(base_pack.GetSize() == 2);
 
-        TextPack disjoint_pack;
-        disjoint_pack.AddStr(99, string_view {"OnlyHere"});
+        TextPack disjoint_pack(TestHashes);
+        disjoint_pack.AddStr(MakeKey("Dialogs", "99"), string_view {"OnlyHere"});
         CHECK_FALSE(base_pack.CheckIntersections(disjoint_pack));
     }
 
     SECTION("GetStrSkipOutOfRangeReturnsEmptyString")
     {
-        TextPack pack;
-        pack.AddStr(5, string_view {"Alpha"});
-        pack.AddStr(5, string_view {"Beta"});
+        TextPack pack(TestHashes);
+        const auto key = MakeKey("Dialogs", "5");
+        pack.AddStr(key, string_view {"Alpha"});
+        pack.AddStr(key, string_view {"Beta"});
 
-        CHECK(pack.GetStr(5, 0) == "Alpha");
-        CHECK(pack.GetStr(5, 1) == "Beta");
-        CHECK(pack.GetStr(5, 2).empty());
-        CHECK(pack.GetStr(42, 0).empty());
+        CHECK(pack.GetStr(key, 0) == "Alpha");
+        CHECK(pack.GetStr(key, 1) == "Beta");
+        CHECK(pack.GetStr(key, 2).empty());
+        CHECK(pack.GetStr(MakeKey("Dialogs", "42"), 0).empty());
     }
 
     SECTION("MalformedLoadFromStringReportsFailureAfterKeepingValidEntries")
     {
-        HashStorage hashes;
-        TextPack pack;
+        TextPack pack(TestHashes);
 
         const string input = "{10}{}{Valid}\n{20}{Broken\n{30}{}{StillValid}";
 
-        CHECK_FALSE(pack.LoadFromString(input, hashes));
-        CHECK(pack.GetStr(10, 0) == "Valid");
-        CHECK(pack.GetStr(20).empty());
-        CHECK(pack.GetStr(30, 0) == "StillValid");
+        CHECK_FALSE(pack.LoadFromString(input, "Dialogs"));
+        CHECK(pack.GetStr(MakeKey("Dialogs", "10"), 0) == "Valid");
+        CHECK(pack.GetStr(MakeKey("Dialogs", "20")).empty());
+        CHECK(pack.GetStr(MakeKey("Dialogs", "30"), 0) == "StillValid");
         CHECK(pack.GetSize() == 2);
     }
 
@@ -184,19 +245,19 @@ TEST_CASE("TextPack")
         vector<string> bake_languages {"engl", "russ", "germ"};
         vector<pair<string, map<string, TextPack>>> lang_packs;
 
-        TextPack engl_dialogs;
-        engl_dialogs.AddStr(1, string_view {"Hello"});
-        engl_dialogs.AddStr(2, string_view {"World"});
+        TextPack engl_dialogs(TestHashes);
+        engl_dialogs.AddStr(MakeKey("Dialogs", "1"), string_view {"Hello"});
+        engl_dialogs.AddStr(MakeKey("Dialogs", "2"), string_view {"World"});
 
-        TextPack engl_items;
-        engl_items.AddStr(10, string_view {"Item"});
+        TextPack engl_items(TestHashes);
+        engl_items.AddStr(MakeKey("Items", "10"), string_view {"Item"});
 
-        TextPack russ_dialogs;
-        russ_dialogs.AddStr(2, string_view {"Mir"});
-        russ_dialogs.AddStr(3, string_view {"Extra"});
+        TextPack russ_dialogs(TestHashes);
+        russ_dialogs.AddStr(MakeKey("Dialogs", "2"), string_view {"Mir"});
+        russ_dialogs.AddStr(MakeKey("Dialogs", "3"), string_view {"Extra"});
 
-        TextPack unsupported_dialogs;
-        unsupported_dialogs.AddStr(1, string_view {"Hola"});
+        TextPack unsupported_dialogs(TestHashes);
+        unsupported_dialogs.AddStr(MakeKey("Dialogs", "1"), string_view {"Hola"});
 
         lang_packs.emplace_back("engl", map<string, TextPack> {});
         lang_packs[0].second.emplace("Dialogs", engl_dialogs);
@@ -219,16 +280,16 @@ TEST_CASE("TextPack")
         REQUIRE(russ_pack.size() == 2);
         CHECK(russ_pack.contains("Dialogs"));
         CHECK(russ_pack.contains("Items"));
-        CHECK(russ_pack.at("Dialogs").GetStr(1, 0) == "Hello");
-        CHECK(russ_pack.at("Dialogs").GetStr(2, 0) == "Mir");
-        CHECK(russ_pack.at("Dialogs").GetStr(3).empty());
-        CHECK(russ_pack.at("Items").GetStr(10, 0) == "Item");
+        CHECK(russ_pack.at("Dialogs").GetStr(MakeKey("Dialogs", "1"), 0) == "Hello");
+        CHECK(russ_pack.at("Dialogs").GetStr(MakeKey("Dialogs", "2"), 0) == "Mir");
+        CHECK(russ_pack.at("Dialogs").GetStr(MakeKey("Dialogs", "3")).empty());
+        CHECK(russ_pack.at("Items").GetStr(MakeKey("Items", "10"), 0) == "Item");
 
         const auto& germ_pack = lang_packs[2].second;
         REQUIRE(germ_pack.size() == 2);
-        CHECK(germ_pack.at("Dialogs").GetStr(1, 0) == "Hello");
-        CHECK(germ_pack.at("Dialogs").GetStr(2, 0) == "World");
-        CHECK(germ_pack.at("Items").GetStr(10, 0) == "Item");
+        CHECK(germ_pack.at("Dialogs").GetStr(MakeKey("Dialogs", "1"), 0) == "Hello");
+        CHECK(germ_pack.at("Dialogs").GetStr(MakeKey("Dialogs", "2"), 0) == "World");
+        CHECK(germ_pack.at("Items").GetStr(MakeKey("Items", "10"), 0) == "Item");
     }
 
     SECTION("FixPacksBootstrapsDefaultLanguageWhenInputIsEmpty")

--- a/Source/Tools/EffectBaker.cpp
+++ b/Source/Tools/EffectBaker.cpp
@@ -174,7 +174,7 @@ void EffectBaker::BakeShaderProgram(string_view fname, string_view content) cons
 {
     FO_STACK_TRACE_ENTRY();
 
-    auto fofx = ConfigFile(fname, string(content), nullptr, ConfigFileOption::CollectContent);
+    auto fofx = ConfigFile(fname, string(content), ConfigFileOption::CollectContent);
 
     if (!fofx.HasSection("Effect")) {
         throw EffectBakerException(".fofx file truncated", fname);

--- a/Source/Tools/MapBaker.cpp
+++ b/Source/Tools/MapBaker.cpp
@@ -130,7 +130,7 @@ void MapBaker::BakeFiles(const FileCollection& files, string_view target_path) c
         const string& file_content = file.GetStr();
 
         string map_name = [&]() -> string {
-            const auto fomap = ConfigFile(file.GetPath(), file_content, nullptr, ConfigFileOption::ReadFirstSection);
+            const auto fomap = ConfigFile(file.GetPath(), file_content, ConfigFileOption::ReadFirstSection);
             return string(fomap.GetAsStr("Header", "$Name", file.GetNameNoExt()));
         }();
 

--- a/Source/Tools/Mapper.cpp
+++ b/Source/Tools/Mapper.cpp
@@ -544,8 +544,8 @@ MapperEngine::MapperEngine(GlobalSettings& settings, FileSystem&& resources, IAp
 
     InitSubsystems(this);
 
-    _curLang = LanguagePack {Settings.Language, *this};
-    _curLang.LoadFromResources(Resources);
+    _curLang = TextPack {Hashes};
+    _curLang.LoadFromResources(Resources, Settings.Language);
 
     // Fonts
     auto load_fonts_ok = true;
@@ -4783,7 +4783,7 @@ auto MapperEngine::TryMergeItemToMultihexMesh(MapView* map, ItemHexView* item, b
         }
 
         auto sorted_target_items = vec_sorted(target_items, [](auto&& i1, auto&& i2) { return i1->GetId() < i2->GetId(); });
-        auto sorted_source_items = vec_sorted(source_items, [](auto&& i1, auto&& i2) { return i1->GetId() > i2->GetId(); });
+        auto sorted_source_items = vec_sorted(source_items, [](auto&& i1, auto&& i2) { return i2->GetId() < i1->GetId(); });
 
         if (skip_selected) {
             sorted_target_items = vec_filter(sorted_target_items, [&](auto&& i) { return !SelectedEntitiesSet.contains(i); });
@@ -4812,8 +4812,8 @@ auto MapperEngine::TryMergeItemToMultihexMesh(MapView* map, ItemHexView* item, b
             }
 
             if (CompareMultihexItemForMerge(check_item.get(), item, false)) {
-                source_item = check_item->GetId() > item->GetId() ? check_item.get() : item;
-                target_item = check_item->GetId() > item->GetId() ? item : check_item.get();
+                source_item = item->GetId() < check_item->GetId() ? check_item.get() : item;
+                target_item = item->GetId() < check_item->GetId() ? item : check_item.get();
                 break;
             }
         }
@@ -5893,7 +5893,7 @@ auto MapperEngine::LoadMapFromText(string_view map_name, const string& map_text)
 {
     FO_STACK_TRACE_ENTRY();
 
-    const auto map_data = ConfigFile(strex("{}.fomap", map_name), map_text, &Hashes, ConfigFileOption::ReadFirstSection);
+    const auto map_data = ConfigFile(strex("{}.fomap", map_name), map_text, ConfigFileOption::ReadFirstSection);
 
     if (!map_data.HasSection("ProtoMap")) {
         throw MapLoaderException("Invalid map format", map_name);

--- a/Source/Tools/ProtoBaker.cpp
+++ b/Source/Tools/ProtoBaker.cpp
@@ -134,7 +134,7 @@ auto ProtoBaker::BakeProtoFiles(EngineMetadata* meta, const ScriptSystem* script
     for (const auto& file : files) {
         const bool is_fomap = strex(file.GetPath()).get_file_extension() == "fomap";
         const auto fopro_options = is_fomap ? ConfigFileOption::ReadFirstSection : ConfigFileOption::None;
-        auto fopro = ConfigFile(file.GetPath(), file.GetStr(), &meta->Hashes, fopro_options);
+        auto fopro = ConfigFile(file.GetPath(), file.GetStr(), fopro_options);
 
         for (const auto& [section_name, section_kv_view] : fopro.GetSections()) {
             // Skip default section

--- a/Source/Tools/ProtoTextBaker.cpp
+++ b/Source/Tools/ProtoTextBaker.cpp
@@ -98,6 +98,10 @@ void ProtoTextBaker::BakeFiles(const FileCollection& files, string_view target_p
 
     const auto engine = BakerServerEngine(*_context->BakedFiles);
     const auto proto_rule_name = engine.Hashes.ToHashedString("Proto");
+    const auto item_type_name = engine.Hashes.ToHashedString("Item");
+    const auto critter_type_name = engine.Hashes.ToHashedString("Critter");
+    const auto map_type_name = engine.Hashes.ToHashedString("Map");
+    const auto location_type_name = engine.Hashes.ToHashedString("Location");
 
     // Collect data
     unordered_map<hstring, unordered_map<hstring, map<string, string>>> all_file_protos;
@@ -105,7 +109,7 @@ void ProtoTextBaker::BakeFiles(const FileCollection& files, string_view target_p
     for (const auto& file : filtered_files) {
         const bool is_fomap = strex(file.GetPath()).get_file_extension() == "fomap";
         const auto fopro_options = is_fomap ? ConfigFileOption::ReadFirstSection : ConfigFileOption::None;
-        auto fopro = ConfigFile(file.GetPath(), file.GetStr(), &engine.Hashes, fopro_options);
+        auto fopro = ConfigFile(file.GetPath(), file.GetStr(), fopro_options);
 
         for (const auto& [section_name, section_kv_view] : fopro.GetSections()) {
             // Skip default section
@@ -215,28 +219,37 @@ void ProtoTextBaker::BakeFiles(const FileCollection& files, string_view target_p
 
             all_proto_texts[type_name][pid] = {};
 
+            const auto text_pack_name = [&]() -> string_view {
+                if (type_name == item_type_name) {
+                    return "Items";
+                }
+                if (type_name == critter_type_name) {
+                    return "Critters";
+                }
+                if (type_name == map_type_name) {
+                    return "Maps";
+                }
+                if (type_name == location_type_name) {
+                    return "Locations";
+                }
+                return "Protos";
+            }();
+
             for (auto&& [key, value] : proto_kv) {
                 FO_RUNTIME_ASSERT(strvex(key).starts_with("$Text"));
 
                 const auto key_tok = strex(key).split(' ');
                 const string lang = key_tok.size() >= 2 ? key_tok[1] : default_lang;
 
-                TextPackKey text_key = pid.as_uint32();
+                FO_RUNTIME_ASSERT(key_tok.size() <= 4);
 
-                for (size_t i = 2; i < key_tok.size(); i++) {
-                    const string& num = key_tok[i];
+                const string_view key2 = key_tok.size() >= 3 ? string_view {key_tok[2]} : string_view {};
+                const string_view key3 = key_tok.size() >= 4 ? string_view {key_tok[3]} : string_view {};
+                const auto text_key = TextPackKey::FromPack(engine.Hashes, text_pack_name, pid.as_str(), key2, key3);
 
-                    if (!num.empty()) {
-                        if (strvex(num).is_number()) {
-                            text_key += strvex(num).to_uint32();
-                        }
-                        else {
-                            text_key += engine.Hashes.ToHashedString(num).as_uint32();
-                        }
-                    }
-                }
-
-                all_proto_texts[type_name][pid][lang].AddStr(text_key, StringEscaping::DecodeString(value));
+                auto& lang_packs_map = all_proto_texts[type_name][pid];
+                lang_packs_map.try_emplace(lang, engine.Hashes);
+                lang_packs_map.at(lang).AddStr(text_key, StringEscaping::DecodeString(value));
             }
         }
     }
@@ -247,22 +260,21 @@ void ProtoTextBaker::BakeFiles(const FileCollection& files, string_view target_p
 
     for (const auto& lang : _context->Settings->BakeLanguages) {
         auto empty_lang_pack = map<string, TextPack>();
-        empty_lang_pack["Items"] = {};
-        empty_lang_pack["Critters"] = {};
-        empty_lang_pack["Maps"] = {};
-        empty_lang_pack["Locations"] = {};
-        empty_lang_pack["Protos"] = {};
+        empty_lang_pack.try_emplace("Items", engine.Hashes);
+        empty_lang_pack.try_emplace("Critters", engine.Hashes);
+        empty_lang_pack.try_emplace("Maps", engine.Hashes);
+        empty_lang_pack.try_emplace("Locations", engine.Hashes);
+        empty_lang_pack.try_emplace("Protos", engine.Hashes);
         lang_packs.emplace_back(lang, std::move(empty_lang_pack));
     }
 
-    const auto fill_proto_texts = [&](hstring entity_name, TextPackName pack_name) {
+    const auto fill_proto_texts = [&](hstring entity_name, string_view pack_name) {
         for (auto&& [pid, proto_texts] : all_proto_texts[entity_name]) {
             for (const auto& proto_text : proto_texts) {
                 const auto it = std::ranges::find_if(lang_packs, [&](auto&& l) { return l.first == proto_text.first; });
 
                 if (it != lang_packs.end()) {
-                    const auto& pack_name_str = engine.ResolveEnumValueName("TextPackName", static_cast<int32>(pack_name));
-                    auto& text_pack = it->second[pack_name_str];
+                    auto& text_pack = it->second.at(string(pack_name));
 
                     if (text_pack.CheckIntersections(proto_text.second)) {
                         WriteLog("Proto text intersection detected for proto {} and pack {}", pid, pack_name);
@@ -278,14 +290,14 @@ void ProtoTextBaker::BakeFiles(const FileCollection& files, string_view target_p
         }
     };
 
-    fill_proto_texts(engine.Hashes.ToHashedString("Item"), TextPackName::Items);
-    fill_proto_texts(engine.Hashes.ToHashedString("Critter"), TextPackName::Critters);
-    fill_proto_texts(engine.Hashes.ToHashedString("Map"), TextPackName::Maps);
-    fill_proto_texts(engine.Hashes.ToHashedString("Location"), TextPackName::Locations);
+    fill_proto_texts(item_type_name, "Items");
+    fill_proto_texts(critter_type_name, "Critters");
+    fill_proto_texts(map_type_name, "Maps");
+    fill_proto_texts(location_type_name, "Locations");
 
     for (auto&& [type_name, type_desc] : engine.GetEntityTypes()) {
         if (!type_desc.Exported && type_desc.HasProtos) {
-            fill_proto_texts(type_name, TextPackName::Protos);
+            fill_proto_texts(type_name, "Protos");
         }
     }
 

--- a/Source/Tools/TextBaker.cpp
+++ b/Source/Tools/TextBaker.cpp
@@ -143,7 +143,7 @@ void TextBaker::BakeFiles(const FileCollection& files, string_view target_path) 
 
     // Parse texts
     vector<pair<string, map<string, TextPack>>> lang_packs;
-    HashStorage hashes;
+    HashStorage hashes {};
 
     for (const auto& target_lang : languages) {
         map<string, TextPack> lang_pack;
@@ -155,10 +155,10 @@ void TextBaker::BakeFiles(const FileCollection& files, string_view target_path) 
             const auto& lang_name = name_pair[1];
 
             if (lang_name == target_lang) {
-                TextPack text_pack;
+                TextPack text_pack {hashes};
 
-                if (!text_pack.LoadFromString(file.GetStr(), hashes)) {
-                    throw LanguagePackException("Invalid text file", file.GetPath());
+                if (!text_pack.LoadFromString(file.GetStr(), text_pack_name)) {
+                    throw TextPackException("Invalid text file", file.GetPath());
                 }
 
                 lang_pack.emplace(text_pack_name, std::move(text_pack));


### PR DESCRIPTION
- Removed unused `ResolveGenericValue` method from `Test_Properties.cpp`.
- Initialized `HashStorage` with default constructor in multiple test cases for consistency.
- Updated hash calculation method in `Test_RemoteCallValidation.cpp` to use `hashing_ex::hash`.
- Added new functions for enum to string conversions in `Test_ScriptBuiltins.cpp`.
- Simplified calls to `Game.IsTextPresent` in `Test_ServerScriptMethods.cpp`.
- Cleaned up `ConfigFile` constructor calls in various tools to remove unnecessary parameters.
- Enhanced `TextPack` handling in `Test_TextPack.cpp` to use structured keys for better readability.
- Improved error handling and logging in `ProtoTextBaker.cpp` and `TextBaker.cpp` for better debugging.