### PR TITLE
Spectator mode

### DIFF
--- a/Source/Applications/MapperApp.cpp
+++ b/Source/Applications/MapperApp.cpp
@@ -101,8 +101,6 @@ int main(int argc, char** argv) // Handled by SDL
     try {
         InitApp(numeric_cast<int32_t>(argc), argv, AppInitFlags::ShowMessageOnException);
 
-        App->Settings.ScreenHudHeight = 0;
-
 #if FO_IOS
         MapperEntry(nullptr);
         App->SetMainLoopCallback(MapperEntry);

--- a/Source/Applications/ServerApp.cpp
+++ b/Source/Applications/ServerApp.cpp
@@ -284,7 +284,7 @@ int main(int argc, char** argv) // Handled by SDL
 
                     const auto tex_w = numeric_cast<float32_t>(tex->Size.width);
                     const auto tex_h = numeric_cast<float32_t>(tex->Size.height);
-                    const auto scale = std::min({1.0f, region.x / tex_w, region.y / tex_h});
+                    const auto scale = std::min(region.x / tex_w, region.y / tex_h);
                     const auto img_size = ImVec2(tex_w * scale, tex_h * scale);
                     const auto cursor = ImGui::GetCursorScreenPos();
                     ImGui::GetWindowDrawList()->AddRectFilled(cursor, ImVec2(cursor.x + region.x, cursor.y + region.y), IM_COL32(0, 0, 0, 255));

--- a/Source/Client/Client.cpp
+++ b/Source/Client/Client.cpp
@@ -1637,10 +1637,13 @@ void ClientEngine::Net_OnLoadMap()
         const auto* map_proto = GetProtoMap(map_pid);
         FO_RUNTIME_ASSERT(map_proto);
 
+        isize32 screen_size = {Settings.ScreenWidth, Settings.ScreenHeight};
+        OnPreLoadMap.Fire(loc_pid, map_pid, screen_size);
+
         _curLocation = SafeAlloc::MakeRefCounted<LocationView>(this, loc_id, loc_proto);
         _curLocation->RestoreData(_tempPropertiesDataExt);
 
-        _curMap = SafeAlloc::MakeRefCounted<MapView>(this, map_id, map_proto);
+        _curMap = SafeAlloc::MakeRefCounted<MapView>(this, map_id, map_proto, screen_size);
         _curMap->RestoreData(_tempPropertiesData);
         _curMap->LoadStaticData();
 

--- a/Source/Client/Client.h
+++ b/Source/Client/Client.h
@@ -223,6 +223,8 @@ public:
     ///@ ExportEvent
     FO_ENTITY_EVENT(OnCustomEntityOut, ClientEntity* /*entity*/);
     ///@ ExportEvent
+    FO_ENTITY_EVENT(OnPreLoadMap, hstring /*locPid*/, hstring /*mapPid*/, isize32& /*screenSize*/);
+    ///@ ExportEvent
     FO_ENTITY_EVENT(OnMapLoad);
     ///@ ExportEvent
     FO_ENTITY_EVENT(OnMapLoaded);

--- a/Source/Client/CritterView.cpp
+++ b/Source/Client/CritterView.cpp
@@ -54,6 +54,14 @@ CritterView::CritterView(ClientEngine* engine, ident_t id, const ProtoCritter* p
 #endif
 }
 
+CritterView::~CritterView()
+{
+    FO_STACK_TRACE_ENTRY();
+
+    FO_RUNTIME_VERIFY(_invItems.empty());
+    FO_RUNTIME_VERIFY(_attachedCritters.empty());
+}
+
 void CritterView::OnDestroySelf()
 {
     FO_STACK_TRACE_ENTRY();

--- a/Source/Client/CritterView.h
+++ b/Source/Client/CritterView.h
@@ -52,7 +52,7 @@ public:
     CritterView(CritterView&&) noexcept = delete;
     auto operator=(const CritterView&) = delete;
     auto operator=(CritterView&&) noexcept = delete;
-    ~CritterView() override = default;
+    ~CritterView() override;
 
     [[nodiscard]] auto GetName() const noexcept -> string_view override { return _name; }
     [[nodiscard]] auto IsAlive() const noexcept -> bool { return GetCondition() == CritterCondition::Alive; }

--- a/Source/Client/ItemView.cpp
+++ b/Source/Client/ItemView.cpp
@@ -46,6 +46,13 @@ ItemView::ItemView(ClientEngine* engine, ident_t id, const ProtoItem* proto, con
     _name = strex("{}_{}", proto->GetName(), id);
 }
 
+ItemView::~ItemView()
+{
+    FO_STACK_TRACE_ENTRY();
+
+    FO_RUNTIME_VERIFY(_innerItems.empty());
+}
+
 void ItemView::OnDestroySelf()
 {
     FO_STACK_TRACE_ENTRY();

--- a/Source/Client/ItemView.h
+++ b/Source/Client/ItemView.h
@@ -50,7 +50,7 @@ public:
     ItemView(ItemView&&) noexcept = delete;
     auto operator=(const ItemView&) = delete;
     auto operator=(ItemView&&) noexcept = delete;
-    ~ItemView() override = default;
+    ~ItemView() override;
 
     [[nodiscard]] auto GetInnerItems() const noexcept -> const vector<refcount_ptr<ItemView>>& { return _innerItems; }
     [[nodiscard]] auto GetInnerItems() noexcept -> vector<refcount_ptr<ItemView>>& { return _innerItems; }

--- a/Source/Client/MapSprite.cpp
+++ b/Source/Client/MapSprite.cpp
@@ -88,7 +88,7 @@ auto MapSprite::GetDrawRect() const noexcept -> irect32
     FO_NO_STACK_TRACE_ENTRY();
 
     const auto* spr = GetSprite();
-    FO_RUNTIME_VERIFY(spr, irect32());
+    FO_RUNTIME_VERIFY_AND_RETURN(spr, irect32());
 
     const ipos32 spr_offset = spr->GetOffset();
     const isize32 spr_size = spr->GetSize();
@@ -108,7 +108,7 @@ auto MapSprite::GetViewRect() const noexcept -> irect32
     FO_NO_STACK_TRACE_ENTRY();
 
     const auto* spr = GetSprite();
-    FO_RUNTIME_VERIFY(spr, irect32());
+    FO_RUNTIME_VERIFY_AND_RETURN(spr, irect32());
 
     auto rect = GetDrawRect();
 

--- a/Source/Client/MapView.cpp
+++ b/Source/Client/MapView.cpp
@@ -3742,9 +3742,14 @@ void MapView::OnScreenSizeChanged()
 {
     FO_STACK_TRACE_ENTRY();
 
-    if (_rtLight && _engine->Settings.MapDirectDraw) {
+    if (_engine->Settings.MapDirectDraw) {
         const auto window_size = App->MainWindow.GetSize();
-        _engine->SprMngr.GetRtMngr().ResizeRenderTarget(_rtLight.get(), window_size);
+
+        SetScreenSize(window_size);
+
+        if (_rtLight) {
+            _engine->SprMngr.GetRtMngr().ResizeRenderTarget(_rtLight.get(), window_size);
+        }
     }
 
     RebuildMapNow();

--- a/Source/Client/MapView.cpp
+++ b/Source/Client/MapView.cpp
@@ -101,6 +101,8 @@ MapView::MapView(ClientEngine* engine, ident_t id, const ProtoMap* proto, isize3
         _rtLight = _engine->SprMngr.GetRtMngr().CreateRenderTarget(false, rt_light_size, true);
     }
 
+    _engine->SprMngr.EnsureContourTargetSize(map_rt_size);
+
     _picHex[0] = _engine->SprMngr.LoadSprite(_engine->Settings.MapDataPrefix + "Hex1.png", AtlasType::MapSprites);
     _picHex[1] = _engine->SprMngr.LoadSprite(_engine->Settings.MapDataPrefix + "Hex2.png", AtlasType::MapSprites);
     _picHex[2] = _engine->SprMngr.LoadSprite(_engine->Settings.MapDataPrefix + "Hex3.png", AtlasType::MapSprites);
@@ -3775,6 +3777,8 @@ void MapView::SetScreenSize(isize32 size)
     if (_rtLight && !_engine->Settings.MapDirectDraw) {
         rt_mngr.ResizeRenderTarget(_rtLight.get(), map_rt_size);
     }
+
+    _engine->SprMngr.EnsureContourTargetSize(map_rt_size);
 
     RebuildMapNow();
 }

--- a/Source/Client/MapView.cpp
+++ b/Source/Client/MapView.cpp
@@ -71,7 +71,7 @@ void SpritePattern::Finish()
     }
 }
 
-MapView::MapView(ClientEngine* engine, ident_t id, const ProtoMap* proto, const Properties* props) :
+MapView::MapView(ClientEngine* engine, ident_t id, const ProtoMap* proto, isize32 screen_size, const Properties* props) :
     ClientEntity(engine, id, engine->GetPropertyRegistrator(ENTITY_TYPE_NAME), props != nullptr ? props : &proto->GetProperties(), &proto->GetProperties()),
     EntityWithProto(proto),
     MapProperties(GetInitRef())
@@ -81,7 +81,7 @@ MapView::MapView(ClientEngine* engine, ident_t id, const ProtoMap* proto, const 
     _name = strex("{}_{}", proto->GetName(), id);
 
     _maxScroll = {GameSettings::MAP_HEX_WIDTH, GameSettings::MAP_HEX_LINE_HEIGHT * 2};
-    _screenSize = {_engine->Settings.ScreenWidth, _engine->Settings.ScreenHeight - _engine->Settings.ScreenHudHeight};
+    _screenSize = screen_size;
     _viewSize = fsize32(_screenSize);
     _scrollCheckEnabled = true;
 
@@ -89,14 +89,16 @@ MapView::MapView(ClientEngine* engine, ident_t id, const ProtoMap* proto, const 
     SetSpritesZoomTarget(1.0f);
     RefreshMinZoom();
 
+    const auto map_rt_size = isize32(_screenSize.width + GameSettings::MAP_HEX_WIDTH, _screenSize.height + GameSettings::MAP_HEX_LINE_HEIGHT * 2);
+
     if (!_engine->Settings.MapDirectDraw) {
-        _rtMap = _engine->SprMngr.GetRtMngr().CreateRenderTarget(false, RenderTarget::SizeKindType::Map, {}, true);
+        _rtMap = _engine->SprMngr.GetRtMngr().CreateRenderTarget(false, map_rt_size, true);
         _rtMap->SetCustomDrawEffect(_engine->EffectMngr.Effects.FlushMap.get());
     }
 
     if (!_engine->Settings.DisableLighting || !_engine->Settings.DisableFog) {
-        const auto tex_size = _engine->Settings.MapDirectDraw ? RenderTarget::SizeKindType::Screen : RenderTarget::SizeKindType::Map;
-        _rtLight = _engine->SprMngr.GetRtMngr().CreateRenderTarget(false, tex_size, {}, true);
+        const auto rt_light_size = _engine->Settings.MapDirectDraw ? App->MainWindow.GetSize() : map_rt_size;
+        _rtLight = _engine->SprMngr.GetRtMngr().CreateRenderTarget(false, rt_light_size, true);
     }
 
     _picHex[0] = _engine->SprMngr.LoadSprite(_engine->Settings.MapDataPrefix + "Hex1.png", AtlasType::MapSprites);
@@ -124,15 +126,19 @@ MapView::~MapView()
 {
     FO_STACK_TRACE_ENTRY();
 
-    for (auto& cr : _critters) {
-        cr->DestroySelf();
-    }
-    for (auto& item : _items) {
-        item->DestroySelf();
-    }
-
-    _engine->SprMngr.GetRtMngr().DeleteRenderTarget(_rtMap.get());
-    _engine->SprMngr.GetRtMngr().DeleteRenderTarget(_rtLight.get());
+    FO_RUNTIME_VERIFY(_critters.empty());
+    FO_RUNTIME_VERIFY(_crittersMap.empty());
+    FO_RUNTIME_VERIFY(_items.empty());
+    FO_RUNTIME_VERIFY(_itemsMap.empty());
+    FO_RUNTIME_VERIFY(_staticItems.empty());
+    FO_RUNTIME_VERIFY(_dynamicItems.empty());
+    FO_RUNTIME_VERIFY(_processingItems.empty());
+    FO_RUNTIME_VERIFY(_spritePatterns.empty());
+    FO_RUNTIME_VERIFY(_fogLayers.empty());
+    FO_RUNTIME_VERIFY(_visibleLightSources.empty());
+    FO_RUNTIME_VERIFY(_lightSources.empty());
+    FO_RUNTIME_VERIFY(!_rtMap);
+    FO_RUNTIME_VERIFY(!_rtLight);
 }
 
 void MapView::OnDestroySelf()
@@ -169,6 +175,15 @@ void MapView::OnDestroySelf()
     _processingItems.clear();
     _itemsMap.clear();
     _spritePatterns.clear();
+
+    if (_rtMap) {
+        _engine->SprMngr.GetRtMngr().DeleteRenderTarget(_rtMap.get());
+        _rtMap = nullptr;
+    }
+    if (_rtLight) {
+        _engine->SprMngr.GetRtMngr().DeleteRenderTarget(_rtLight.get());
+        _rtLight = nullptr;
+    }
 }
 
 void MapView::EnableMapperMode()
@@ -2519,7 +2534,7 @@ void MapView::DrawMap()
             _engine->SprMngr.DrawContours();
 
             // Fog
-            if (!_engine->Settings.DisableFog && !_mapperMode) {
+            if (!_engine->Settings.DisableFog && !_mapperMode && !_fogLayers.empty()) {
                 _engine->SprMngr.GetRtMngr().PushRenderTarget(_rtLight.get());
                 _engine->SprMngr.GetRtMngr().ClearCurrentRenderTarget(ucolor::clear);
 
@@ -3727,8 +3742,34 @@ void MapView::OnScreenSizeChanged()
 {
     FO_STACK_TRACE_ENTRY();
 
-    _screenSize = {_engine->Settings.ScreenWidth, _engine->Settings.ScreenHeight - _engine->Settings.ScreenHudHeight};
+    if (_rtLight && _engine->Settings.MapDirectDraw) {
+        const auto window_size = App->MainWindow.GetSize();
+        _engine->SprMngr.GetRtMngr().ResizeRenderTarget(_rtLight.get(), window_size);
+    }
+
+    RebuildMapNow();
+}
+
+void MapView::SetScreenSize(isize32 size)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    if (_screenSize == size) {
+        return;
+    }
+
+    _screenSize = size;
     _viewSize = fsize32(_screenSize) / GetSpritesZoom();
+
+    auto& rt_mngr = _engine->SprMngr.GetRtMngr();
+    const auto map_rt_size = isize32(_screenSize.width + GameSettings::MAP_HEX_WIDTH, _screenSize.height + GameSettings::MAP_HEX_LINE_HEIGHT * 2);
+
+    if (_rtMap) {
+        rt_mngr.ResizeRenderTarget(_rtMap.get(), map_rt_size);
+    }
+    if (_rtLight && !_engine->Settings.MapDirectDraw) {
+        rt_mngr.ResizeRenderTarget(_rtLight.get(), map_rt_size);
+    }
 
     RebuildMapNow();
 }

--- a/Source/Client/MapView.h
+++ b/Source/Client/MapView.h
@@ -157,7 +157,7 @@ public:
         bool FollowCritter {};
     };
 
-    MapView(ClientEngine* engine, ident_t id, const ProtoMap* proto, const Properties* props = nullptr);
+    MapView(ClientEngine* engine, ident_t id, const ProtoMap* proto, isize32 screen_size, const Properties* props = nullptr);
     MapView(const MapView&) = delete;
     MapView(MapView&&) noexcept = delete;
     auto operator=(const MapView&) = delete;
@@ -192,6 +192,7 @@ public:
     void ClearHexTrack();
     void SwitchShowTrack();
 
+    void SetScreenSize(isize32 size);
     auto ScreenToMapPos(ipos32 screen_pos) const -> ipos32;
     auto MapToScreenPos(ipos32 map_pos) const -> ipos32;
     auto GetScreenRawHex() const -> ipos32;

--- a/Source/Client/ModelSprites.cpp
+++ b/Source/Client/ModelSprites.cpp
@@ -225,7 +225,7 @@ void ModelSpriteFactory::DrawModelToAtlas(ModelSprite* model_spr)
     }
 
     if (rt_model == nullptr) {
-        rt_model = _sprMngr->GetRtMngr().CreateRenderTarget(true, RenderTarget::SizeKindType::Custom, frame_size, true);
+        rt_model = _sprMngr->GetRtMngr().CreateRenderTarget(true, frame_size, true);
         _rtIntermediate.emplace_back(rt_model);
     }
 

--- a/Source/Client/NetworkClient-UdpSockets.cpp
+++ b/Source/Client/NetworkClient-UdpSockets.cpp
@@ -145,7 +145,7 @@ auto NetworkClientConnection_UdpSockets::CheckStatusImpl(bool for_write) -> bool
 
     if (_channel.NeedSend(now) && _socket.can_write()) {
         vector<vector<uint8_t>> packets;
-        ignore_unused(_channel.PrepareOutput({}, packets, now));
+        _channel.PrepareOutput({}, packets, now);
         SendPackets(packets);
     }
 

--- a/Source/Client/ParticleSprites.cpp
+++ b/Source/Client/ParticleSprites.cpp
@@ -196,7 +196,7 @@ void ParticleSpriteFactory::DrawParticleToAtlas(ParticleSprite* particle_spr)
     }
 
     if (rt_intermediate == nullptr) {
-        rt_intermediate = _sprMngr->GetRtMngr().CreateRenderTarget(true, RenderTarget::SizeKindType::Custom, frame_size, true);
+        rt_intermediate = _sprMngr->GetRtMngr().CreateRenderTarget(true, frame_size, true);
         _rtIntermediate.emplace_back(rt_intermediate);
     }
 

--- a/Source/Client/RenderTarget.cpp
+++ b/Source/Client/RenderTarget.cpp
@@ -38,17 +38,13 @@ FO_BEGIN_NAMESPACE
 
 static constexpr auto MAX_STORED_PIXEL_PICKS = 100;
 
-RenderTargetManager::RenderTargetManager(RenderSettings& settings, IAppWindow& window, FlushCallback flush) :
-    _settings {&settings},
-    _window {&window},
-    _render {&window.GetRender()},
+RenderTargetManager::RenderTargetManager(IAppRender& render, FlushCallback flush) :
+    _render {&render},
     _flush {std::move(flush)}
 {
     FO_STACK_TRACE_ENTRY();
 
     FO_RUNTIME_ASSERT(_flush);
-
-    _eventUnsubscriber += _window->GetOnScreenSizeChanged() += [this]() FO_DEFERRED { OnScreenSizeChanged(); };
 }
 
 auto RenderTargetManager::GetRenderTargetStack() -> const vector<raw_ptr<RenderTarget>>&
@@ -72,19 +68,18 @@ auto RenderTargetManager::GetCurrentRenderTarget() const -> const RenderTarget*
     return !_rtStack.empty() ? _rtStack.back().get() : nullptr;
 }
 
-auto RenderTargetManager::CreateRenderTarget(bool with_depth, RenderTarget::SizeKindType size_kind, isize32 base_size, bool linear_filtered) -> RenderTarget*
+auto RenderTargetManager::CreateRenderTarget(bool with_depth, isize32 size, bool linear_filtered) -> RenderTarget*
 {
     FO_STACK_TRACE_ENTRY();
 
-    FO_RUNTIME_ASSERT(base_size.width >= 0);
-    FO_RUNTIME_ASSERT(base_size.height >= 0);
+    FO_RUNTIME_ASSERT(size.width >= 0);
+    FO_RUNTIME_ASSERT(size.height >= 0);
 
     _flush();
 
     auto rt = SafeAlloc::MakeUnique<RenderTarget>();
 
-    rt->_sizeKind = size_kind;
-    rt->_baseSize = base_size;
+    rt->_size = size;
     rt->_lastPixelPicks.reserve(MAX_STORED_PIXEL_PICKS);
 
     AllocateRenderTargetTexture(rt.get(), linear_filtered, with_depth);
@@ -93,16 +88,22 @@ auto RenderTargetManager::CreateRenderTarget(bool with_depth, RenderTarget::Size
     return _rtAll.back().get();
 }
 
-void RenderTargetManager::OnScreenSizeChanged()
+void RenderTargetManager::ResizeRenderTarget(RenderTarget* rt, isize32 size)
 {
     FO_STACK_TRACE_ENTRY();
 
-    // Reallocate fullscreen render targets
-    for (auto& rt : _rtAll) {
-        if (rt->_sizeKind != RenderTarget::SizeKindType::Custom) {
-            AllocateRenderTargetTexture(rt.get(), rt->_texture->LinearFiltered, rt->_texture->WithDepth);
-        }
+    FO_RUNTIME_ASSERT(rt);
+    FO_RUNTIME_ASSERT(size.width >= 0);
+    FO_RUNTIME_ASSERT(size.height >= 0);
+
+    if (rt->_size == size) {
+        return;
     }
+
+    _flush();
+
+    rt->_size = size;
+    AllocateRenderTargetTexture(rt, rt->_texture->LinearFiltered, rt->_texture->WithDepth);
 }
 
 void RenderTargetManager::AllocateRenderTargetTexture(RenderTarget* rt, bool linear_filtered, bool with_depth)
@@ -111,22 +112,9 @@ void RenderTargetManager::AllocateRenderTargetTexture(RenderTarget* rt, bool lin
 
     FO_NON_CONST_METHOD_HINT();
 
-    auto tex_size = rt->_baseSize;
-
-    if (rt->_sizeKind == RenderTarget::SizeKindType::Screen) {
-        tex_size.width += _settings->ScreenWidth;
-        tex_size.height += _settings->ScreenHeight;
-    }
-    else if (rt->_sizeKind == RenderTarget::SizeKindType::Map) {
-        tex_size.width += _settings->ScreenWidth + GameSettings::MAP_HEX_WIDTH;
-        tex_size.height += _settings->ScreenHeight - _settings->ScreenHudHeight + GameSettings::MAP_HEX_LINE_HEIGHT * 2;
-    }
-
+    auto tex_size = rt->_size;
     tex_size.width = std::max(tex_size.width, 1);
     tex_size.height = std::max(tex_size.height, 1);
-
-    FO_RUNTIME_ASSERT(tex_size.width > 0);
-    FO_RUNTIME_ASSERT(tex_size.height > 0);
 
     rt->_texture = _render->CreateTexture(tex_size, linear_filtered, with_depth);
     rt->_texture->FlippedHeight = _render->IsRenderTargetFlipped();

--- a/Source/Client/RenderTarget.h
+++ b/Source/Client/RenderTarget.h
@@ -39,7 +39,6 @@
 
 FO_BEGIN_NAMESPACE
 
-class IAppWindow;
 class IAppRender;
 class RenderTargetManager;
 
@@ -48,17 +47,9 @@ class RenderTarget
     friend class RenderTargetManager;
 
 public:
-    enum class SizeKindType : uint8_t
-    {
-        Custom,
-        Screen,
-        Map,
-    };
-
     [[nodiscard]] auto GetTexture() const noexcept -> const RenderTexture* { return _texture.get(); }
     [[nodiscard]] auto GetTexture() noexcept -> RenderTexture* { return _texture.get(); }
-    [[nodiscard]] auto GetSizeKind() const noexcept -> SizeKindType { return _sizeKind; }
-    [[nodiscard]] auto GetBaseSize() const noexcept -> isize32 { return _baseSize; }
+    [[nodiscard]] auto GetSize() const noexcept -> isize32 { return _size; }
     [[nodiscard]] auto GetCustomDrawEffect() const noexcept -> RenderEffect* { return _customDrawEffect.get(); }
 
     void SetCustomDrawEffect(RenderEffect* effect) const noexcept { _customDrawEffect = effect; }
@@ -66,8 +57,7 @@ public:
 
 private:
     unique_ptr<RenderTexture> _texture {};
-    SizeKindType _sizeKind {};
-    isize32 _baseSize {};
+    isize32 _size {};
     mutable raw_ptr<RenderEffect> _customDrawEffect {};
     mutable vector<tuple<ipos32, ucolor>> _lastPixelPicks {};
 };
@@ -77,14 +67,14 @@ class RenderTargetManager
 public:
     using FlushCallback = function<void()>;
 
-    RenderTargetManager(RenderSettings& settings, IAppWindow& window, FlushCallback flush);
+    RenderTargetManager(IAppRender& render, FlushCallback flush);
     RenderTargetManager(const RenderTargetManager&) = delete;
     RenderTargetManager(RenderTargetManager&&) noexcept = default;
     auto operator=(const RenderTargetManager&) = delete;
     auto operator=(RenderTargetManager&&) noexcept -> RenderTargetManager& = delete;
     ~RenderTargetManager() = default;
 
-    [[nodiscard]] auto CreateRenderTarget(bool with_depth, RenderTarget::SizeKindType size_kind, isize32 base_size, bool linear_filtered) -> RenderTarget*;
+    [[nodiscard]] auto CreateRenderTarget(bool with_depth, isize32 size, bool linear_filtered) -> RenderTarget*;
     [[nodiscard]] auto GetRenderTargetPixel(const RenderTarget* rt, ipos32 pos) const -> ucolor;
     [[nodiscard]] auto GetRenderTargetStack() -> const vector<raw_ptr<RenderTarget>>&;
     [[nodiscard]] auto GetCurrentRenderTarget() const -> const RenderTarget*;
@@ -94,21 +84,18 @@ public:
     void PopRenderTarget();
     void ClearCurrentRenderTarget(ucolor color, bool with_depth = false);
     void DeleteRenderTarget(RenderTarget* rt);
+    void ResizeRenderTarget(RenderTarget* rt, isize32 size);
 
     void ClearStack();
     void DumpTextures() const;
 
 private:
-    void OnScreenSizeChanged();
     void AllocateRenderTargetTexture(RenderTarget* rt, bool linear_filtered, bool with_depth);
 
-    raw_ptr<RenderSettings> _settings;
-    raw_ptr<IAppWindow> _window;
     raw_ptr<IAppRender> _render;
     FlushCallback _flush;
     vector<unique_ptr<RenderTarget>> _rtAll {};
     vector<raw_ptr<RenderTarget>> _rtStack {};
-    EventUnsubscriber _eventUnsubscriber {};
     bool _nonConstHelper {};
 };
 

--- a/Source/Client/SpriteManager.cpp
+++ b/Source/Client/SpriteManager.cpp
@@ -67,7 +67,7 @@ SpriteManager::SpriteManager(RenderSettings& settings, IAppWindow& window, FileS
     _window {&window},
     _resources {&resources},
     _gameTimer {&game_time},
-    _rtMngr(settings, *_window, [this]() FO_DEFERRED { Flush(); }),
+    _rtMngr(_window->GetRender(), [this]() FO_DEFERRED { Flush(); }),
     _atlasMngr(settings, _rtMngr),
     _render {&_window->GetRender()},
     _input {&_window->GetInput()},
@@ -96,12 +96,26 @@ SpriteManager::SpriteManager(RenderSettings& settings, IAppWindow& window, FileS
     _contourDrawBuf->Indices = {0, 1, 3, 1, 2, 3};
     _contourDrawBuf->IndCount = 6;
 
+    const auto window_size = _window->GetSize();
+    const auto map_rt_size = isize32(window_size.width + GameSettings::MAP_HEX_WIDTH, window_size.height + GameSettings::MAP_HEX_LINE_HEIGHT * 2);
+
 #if !FO_DIRECT_SPRITES_DRAW
-    _rtMain = _rtMngr.CreateRenderTarget(false, RenderTarget::SizeKindType::Screen, {}, true);
+    _rtMain = _rtMngr.CreateRenderTarget(false, window_size, true);
 #endif
-    _rtContours = _rtMngr.CreateRenderTarget(false, RenderTarget::SizeKindType::Map, {}, true);
+    _rtContours = _rtMngr.CreateRenderTarget(false, map_rt_size, true);
 
     _eventUnsubscriber += _window->GetOnLowMemory() += [this]() FO_DEFERRED { CleanupSpriteCache(); };
+    _eventUnsubscriber += _window->GetOnScreenSizeChanged() += [this]() FO_DEFERRED {
+        const auto new_window_size = _window->GetSize();
+        const auto new_map_rt_size = isize32(new_window_size.width + GameSettings::MAP_HEX_WIDTH, new_window_size.height + GameSettings::MAP_HEX_LINE_HEIGHT * 2);
+
+        if (_rtMain) {
+            _rtMngr.ResizeRenderTarget(_rtMain.get(), new_window_size);
+        }
+        if (_rtContours) {
+            _rtMngr.ResizeRenderTarget(_rtContours.get(), new_map_rt_size);
+        }
+    };
 }
 
 auto SpriteManager::Random(int32_t min_value, int32_t max_value) -> int32_t

--- a/Source/Client/SpriteManager.cpp
+++ b/Source/Client/SpriteManager.cpp
@@ -107,13 +107,9 @@ SpriteManager::SpriteManager(RenderSettings& settings, IAppWindow& window, FileS
     _eventUnsubscriber += _window->GetOnLowMemory() += [this]() FO_DEFERRED { CleanupSpriteCache(); };
     _eventUnsubscriber += _window->GetOnScreenSizeChanged() += [this]() FO_DEFERRED {
         const auto new_window_size = _window->GetSize();
-        const auto new_map_rt_size = isize32(new_window_size.width + GameSettings::MAP_HEX_WIDTH, new_window_size.height + GameSettings::MAP_HEX_LINE_HEIGHT * 2);
 
         if (_rtMain) {
             _rtMngr.ResizeRenderTarget(_rtMain.get(), new_window_size);
-        }
-        if (_rtContours) {
-            _rtMngr.ResizeRenderTarget(_rtContours.get(), new_map_rt_size);
         }
     };
 }
@@ -1328,6 +1324,15 @@ void SpriteManager::DrawContours()
         _rtMngr.PopRenderTarget();
 
         _contoursAdded = false;
+    }
+}
+
+void SpriteManager::EnsureContourTargetSize(isize32 size)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    if (_rtContours && _rtContours->GetSize() != size) {
+        _rtMngr.ResizeRenderTarget(_rtContours.get(), size);
     }
 }
 

--- a/Source/Client/SpriteManager.h
+++ b/Source/Client/SpriteManager.h
@@ -208,6 +208,7 @@ public:
     void Flush();
 
     void DrawContours();
+    void EnsureContourTargetSize(isize32 size);
 
     void SetEgg(TransparentEggSlot slot, mpos hex, const MapSprite* mspr);
     void SetEgg(TransparentEggSlot slot, mpos hex, fpos32 center, fsize32 radius);

--- a/Source/Client/TextureAtlas.cpp
+++ b/Source/Client/TextureAtlas.cpp
@@ -41,7 +41,7 @@ static constexpr int32_t ATLAS_SPRITES_PADDING = 1;
 TextureAtlas::TextureAtlas(AtlasType type, RenderTarget* rt) noexcept :
     _type {type},
     _rt {rt},
-    _rootNode {SafeAlloc::MakeUnique<SpaceNode>(nullptr, ipos32(), rt->GetBaseSize())}
+    _rootNode {SafeAlloc::MakeUnique<SpaceNode>(nullptr, ipos32(), rt->GetSize())}
 {
     _rt->GetTexture()->FlippedHeight = false;
 }
@@ -191,7 +191,7 @@ auto TextureAtlasManager::CreateAtlas(AtlasType atlas_type, isize32 request_size
     FO_RUNTIME_ASSERT(result_size.width >= request_size.width);
     FO_RUNTIME_ASSERT(result_size.height >= request_size.height);
 
-    auto* rt = _rtMngr->CreateRenderTarget(false, RenderTarget::SizeKindType::Custom, result_size, _settings->AtlasLinearFiltration);
+    auto* rt = _rtMngr->CreateRenderTarget(false, result_size, _settings->AtlasLinearFiltration);
     auto atlas = SafeAlloc::MakeUnique<TextureAtlas>(atlas_type, rt);
 
     _allAtlases.push_back(std::move(atlas));

--- a/Source/Client/TextureAtlas.h
+++ b/Source/Client/TextureAtlas.h
@@ -80,7 +80,7 @@ public:
     ~TextureAtlas() = default;
 
     [[nodiscard]] auto GetType() const noexcept -> AtlasType { return _type; }
-    [[nodiscard]] auto GetSize() const noexcept -> isize32 { return _rt->GetBaseSize(); }
+    [[nodiscard]] auto GetSize() const noexcept -> isize32 { return _rt->GetSize(); }
     [[nodiscard]] auto GetRenderTarget() const noexcept -> const RenderTarget* { return _rt.get(); }
     [[nodiscard]] auto GetRenderTarget() noexcept -> RenderTarget* { return _rt.get(); }
     [[nodiscard]] auto GetTexture() const noexcept -> const RenderTexture* { return _rt->GetTexture(); }

--- a/Source/Common/EngineBase.cpp
+++ b/Source/Common/EngineBase.cpp
@@ -392,7 +392,7 @@ void EngineMetadata::RegisterRefTypeLayout(string_view name, const vector<pair<s
     auto fields_registrator = SafeAlloc::MakeUnique<PropertyRegistrator>(strex("{}RefType", name), _side, Hashes, *this);
 
     for (const auto& [field_name, field_type] : layout) {
-        ignore_unused(fields_registrator->RegisterProperty({"Common", field_type, field_name}));
+        fields_registrator->RegisterProperty({"Common", field_type, field_name});
     }
 
     ref_type.FieldsRegistrator = fields_registrator.get();

--- a/Source/Common/NetworkUdp.h
+++ b/Source/Common/NetworkUdp.h
@@ -48,7 +48,7 @@ enum class UdpPacketType : uint8_t
     Disconnect = 5,
 };
 
-struct UdpTransportOptions final
+struct UdpTransportOptions
 {
     size_t MaxPayload {};
     size_t MaxPendingBytes {};
@@ -57,7 +57,7 @@ struct UdpTransportOptions final
     uint32_t Redundancy {};
 };
 
-struct UdpPacketInfo final
+struct UdpPacketInfo
 {
     UdpPacketType Type {};
     uint32_t SessionId {};
@@ -78,14 +78,14 @@ public:
     auto operator=(UdpOrderedChannel&&) noexcept = delete;
     ~UdpOrderedChannel() = default;
 
-    void Reset() noexcept;
-    void SetSessionId(uint32_t session_id) noexcept;
     [[nodiscard]] auto GetSessionId() const noexcept -> uint32_t;
     [[nodiscard]] auto HasSession() const noexcept -> bool;
     [[nodiscard]] auto HasReadyData() const noexcept -> bool;
     [[nodiscard]] auto CanAcceptPayload() const noexcept -> bool;
     [[nodiscard]] auto NeedSend(nanotime now) const noexcept -> bool;
 
+    void Reset() noexcept;
+    void SetSessionId(uint32_t session_id) noexcept;
     auto PrepareOutput(const_span<uint8_t> new_data, vector<vector<uint8_t>>& packets, nanotime now) -> size_t;
     void HandleIncomingPayload(const UdpPacketInfo& packet);
     auto ExtractReadyData(vector<uint8_t>& data) -> size_t;
@@ -100,13 +100,14 @@ private:
         uint32_t SendCount {};
     };
 
+    [[nodiscard]] auto IsPacketAcknowledged(uint32_t sequence, uint32_t ack_sequence, uint32_t ack_bits) const noexcept -> bool;
+    [[nodiscard]] auto MakePacket(UdpPacketType type, uint32_t sequence, const_span<uint8_t> payload, uint32_t value = 0) const -> vector<uint8_t>;
+
     void ApplyAcknowledgements(uint32_t ack_sequence, uint32_t ack_bits);
     void EmitPendingPacket(const PendingPacket& packet, vector<vector<uint8_t>>& packets) const;
     void EmitAckPacket(vector<vector<uint8_t>>& packets) const;
     void RebuildAckBits() noexcept;
     void QueueTailRedundancy(vector<vector<uint8_t>>& packets, uint32_t first_new_sequence) const;
-    [[nodiscard]] auto IsPacketAcknowledged(uint32_t sequence, uint32_t ack_sequence, uint32_t ack_bits) const noexcept -> bool;
-    [[nodiscard]] auto MakePacket(UdpPacketType type, uint32_t sequence, const_span<uint8_t> payload, uint32_t value = 0) const -> vector<uint8_t>;
 
     UdpTransportOptions _options {};
     uint32_t _sessionId {};

--- a/Source/Common/PropertiesSerializator.cpp
+++ b/Source/Common/PropertiesSerializator.cpp
@@ -432,7 +432,7 @@ static void AppendBaseTypeFromText(vector<uint8_t>& data, const Property* prop, 
 
         if (strvex(decoded).is_number()) {
             enum_value = numeric_cast<int32_t>(strvex(decoded).to_int64());
-            ignore_unused(name_resolver.ResolveEnumValueName(base_type.Name, enum_value));
+            (void)name_resolver.ResolveEnumValueName(base_type.Name, enum_value);
         }
         else {
             enum_value = name_resolver.ResolveEnumValue(base_type.Name, decoded);

--- a/Source/Common/ScriptSystem.cpp
+++ b/Source/Common/ScriptSystem.cpp
@@ -315,7 +315,7 @@ auto ScriptSystem::ValidateArgs(const ScriptFuncDesc* func, const_span<size_t> a
 
     const auto check_type = [this](const ComplexTypeDesc& left, size_t right) -> bool {
         const auto it = _engineTypes.find(right);
-        FO_RUNTIME_VERIFY(it != _engineTypes.end(), false);
+        FO_RUNTIME_VERIFY_AND_RETURN(it != _engineTypes.end(), false);
         return left == it->second;
     };
 

--- a/Source/Common/Settings-Include.h
+++ b/Source/Common/Settings-Include.h
@@ -119,7 +119,6 @@ VARIABLE_SETTING(int32_t, View, ScreenWidth, 1024); // Screen width in pixels
 VARIABLE_SETTING(int32_t, View, ScreenHeight, 768); // Screen height in pixels
 FIXED_SETTING(int32_t, View, MonitorWidth); // Monitor width (read only)
 FIXED_SETTING(int32_t, View, MonitorHeight); // Monitor height (read only)
-VARIABLE_SETTING(int32_t, View, ScreenHudHeight, 0); // Screen HUD height in pixels
 VARIABLE_SETTING(bool, View, ShowCorners, false); // If true, corners are shown
 VARIABLE_SETTING(bool, View, ShowSpriteBorders, false); // If true, sprite borders are shown
 FIXED_SETTING(bool, View, HideNativeCursor, false); // If true, native cursor is hidden

--- a/Source/Common/TwoDimensionalGrid.h
+++ b/Source/Common/TwoDimensionalGrid.h
@@ -45,8 +45,8 @@ public:
     {
         FO_STACK_TRACE_ENTRY();
 
-        FO_RUNTIME_VERIFY(size.width >= 0);
-        FO_RUNTIME_VERIFY(size.height >= 0);
+        FO_RUNTIME_VERIFY_AND_RETURN(size.width >= 0);
+        FO_RUNTIME_VERIFY_AND_RETURN(size.height >= 0);
 
         _size = size;
     }
@@ -83,7 +83,9 @@ public:
     {
         FO_NO_STACK_TRACE_ENTRY();
 
-        FO_RUNTIME_VERIFY(base::_size.is_valid_pos(pos), _emptyCell);
+        if (!base::_size.is_valid_pos(pos)) {
+            return _emptyCell;
+        }
 
         const auto it = _cells.find(pos);
 
@@ -160,7 +162,9 @@ public:
     {
         FO_NO_STACK_TRACE_ENTRY();
 
-        FO_RUNTIME_VERIFY(base::_size.is_valid_pos(pos), _emptyCell);
+        if (!base::_size.is_valid_pos(pos)) {
+            return _emptyCell;
+        }
 
         const auto index = static_cast<size_t>(static_cast<int64_t>(pos.y) * base::_size.width + pos.x);
         auto& cell = _preallocatedCells[index];

--- a/Source/Essentials/ExceptionHandling.h
+++ b/Source/Essentials/ExceptionHandling.h
@@ -157,7 +157,11 @@ private:
     if (!(expr)) [[unlikely]] { \
         throw FO_NAMESPACE AssertationException(str, __FILE__, __LINE__); \
     }
-#define FO_RUNTIME_VERIFY(expr, ...) \
+#define FO_RUNTIME_VERIFY(expr) \
+    if (!(expr)) [[unlikely]] { \
+        FO_NAMESPACE ReportVerifyFailed(#expr, __FILE__, __LINE__); \
+    }
+#define FO_RUNTIME_VERIFY_AND_RETURN(expr, ...) \
     if (!(expr)) [[unlikely]] { \
         FO_NAMESPACE ReportVerifyFailed(#expr, __FILE__, __LINE__); \
         return __VA_ARGS__; \
@@ -170,6 +174,7 @@ private:
 #define FO_RUNTIME_ASSERT(expr)
 #define FO_RUNTIME_ASSERT_STR(expr, str)
 #define FO_RUNTIME_VERIFY(expr, ...)
+#define FO_RUNTIME_VERIFY_AND_RETURN(expr, ...)
 #define FO_STRONG_ASSERT(expr)
 #endif
 

--- a/Source/Frontend/Application.cpp
+++ b/Source/Frontend/Application.cpp
@@ -1801,8 +1801,30 @@ void Application::BeginFrame()
             const bool is_main = (resized_window == static_cast<SDL_Window*>(MainWindow._windowHandle.get()));
 
             if (is_main && (Settings.ScreenWidth != width || Settings.ScreenHeight != height)) {
+                const isize32 old_host {Settings.ScreenWidth, Settings.ScreenHeight};
+                const isize32 new_host {width, height};
+
                 Settings.ScreenWidth = width;
                 Settings.ScreenHeight = height;
+
+                if (old_host.width > 0 && old_host.height > 0) {
+                    const auto scale = [](int32_t value, int32_t old_dim, int32_t new_dim) { //
+                        return iround<int32_t>(numeric_cast<float32_t>(value) * numeric_cast<float32_t>(new_dim) / numeric_cast<float32_t>(old_dim));
+                    };
+
+                    for (auto& window : _allWindows) {
+                        if (window->_isVirtual && window->_displayRect.width > 0 && window->_displayRect.height > 0) {
+                            const auto r = window->_displayRect;
+                            window->_displayRect = irect32 {
+                                //
+                                scale(r.x, old_host.width, new_host.width), //
+                                scale(r.y, old_host.height, new_host.height), //
+                                scale(r.width, old_host.width, new_host.width), //
+                                scale(r.height, old_host.height, new_host.height),
+                            };
+                        }
+                    }
+                }
             }
 
             _ctx->ActiveRenderer->OnResizeWindow({width, height});

--- a/Source/Frontend/Application.cpp
+++ b/Source/Frontend/Application.cpp
@@ -559,8 +559,8 @@ Application::~Application()
 
     if (MainWindow._windowHandle) {
         if (_ctx->ActiveRendererType != RenderType::Null) {
-            SDL_StopTextInput(reinterpret_cast<SDL_Window*>(MainWindow._windowHandle.get_no_const()));
-            SDL_DestroyWindow(reinterpret_cast<SDL_Window*>(MainWindow._windowHandle.get_no_const()));
+            SDL_StopTextInput(reinterpret_cast<SDL_Window*>(MainWindow._windowHandle.get()));
+            SDL_DestroyWindow(reinterpret_cast<SDL_Window*>(MainWindow._windowHandle.get()));
         }
 
         MainWindow._windowHandle = nullptr;
@@ -633,8 +633,6 @@ auto Application::CreateChildWindow(isize32 size, string_view title) -> AppWindo
     _allWindows.emplace_back(ptr);
     _childWindows.emplace_back(std::move(window));
 
-    // A freshly spawned window always grabs focus — keeps the test bench predictable
-    // (e.g. spawning a client and immediately interacting with it without manual tab clicking).
     _activeWindow = ptr;
 
     return ptr;
@@ -650,7 +648,7 @@ void Application::DestroyChildWindow(AppWindow* window)
         return;
     }
 
-    std::erase_if(_allWindows, [&](const auto& entry) { return entry.get_no_const() == window; });
+    std::erase_if(_allWindows, [&](auto&& entry) { return entry.get() == window; });
 
     const auto it = std::ranges::find_if(_childWindows, [&](const auto& entry) { return entry.get() == window; });
 
@@ -658,11 +656,11 @@ void Application::DestroyChildWindow(AppWindow* window)
         return;
     }
 
-    if (_activeWindow.get_no_const() == window) {
+    if (_activeWindow.get() == window) {
         _activeWindow = !_childWindows.empty() && _childWindows.front().get() != window ? _childWindows.front().get() : &MainWindow;
     }
 
-    if (_currentRenderingWindow.get_no_const() == window) {
+    if (_currentRenderingWindow.get() == window) {
         EndWindowRender();
     }
 
@@ -696,15 +694,11 @@ void Application::EnsureVirtualRenderTexture(AppWindow* window, isize32 size)
 
     FO_RUNTIME_ASSERT(window);
     FO_RUNTIME_ASSERT(window->_isVirtual);
-
-    // Render at the window's logical size (always Settings.ScreenWidth × Settings.ScreenHeight by default).
-    // The display rect that the texture is scaled to lives in `window->_displayRect` and is set by the layout pass.
     ignore_unused(size);
 
     isize32 desired = window->_virtualSize.width > 0 && window->_virtualSize.height > 0 //
         ?
-        window->_virtualSize //
-        :
+        window->_virtualSize :
         isize32 {Settings.ScreenWidth, Settings.ScreenHeight};
 
     if (!window->_virtualRenderTex || window->_virtualRenderTex->Size != desired) {
@@ -745,8 +739,6 @@ void Application::BeginWindowRender(AppWindow* window)
         Settings.ScreenHeight = window->_virtualSize.height;
     }
 
-    // Start each frame with an opaque black background so untouched pixels don't bleed the host
-    // backbuffer through ImGui::Image's alpha blending.
     Render.ClearRenderTarget(ucolor {0, 0, 0, 255}, true, false);
 }
 
@@ -761,7 +753,7 @@ void Application::EndWindowRender()
     }
 
     const bool was_virtual = _currentRenderingWindow->_isVirtual;
-    auto* prev = _previousRenderTarget.get_no_const();
+    auto* prev = _previousRenderTarget.get();
 
     _previousRenderTarget = nullptr;
     _currentRenderingWindow = nullptr;
@@ -1140,13 +1132,9 @@ void Application::UpdateNativeCursorVisibility(bool imguiOverlayWantsCursor)
         should_hide_cursor = true;
     }
     else if (!_childWindows.empty()) {
-        // Multi-window test bench: keep the OS cursor visible over engine chrome (tab bar, server panel)
-        // and over the virtual viewport — clients render at a different scale than the host, so a game-drawn
-        // cursor wouldn't track 1:1 anyway. The user explicitly relies on the native cursor here.
         should_hide_cursor = false;
     }
     else {
-        // Single-window legacy path: keep historical behavior — game owns the cursor when it wants to.
         should_hide_cursor = Settings.HideNativeCursor && !imguiOverlayWantsCursor;
     }
 
@@ -2165,6 +2153,7 @@ void AppWindow::Minimize()
     FO_NON_CONST_METHOD_HINT();
 
     if (_isVirtual) {
+        _app->MainWindow.Minimize();
         return;
     }
 
@@ -2181,7 +2170,7 @@ auto AppWindow::IsFullscreen() const -> bool
     FO_STACK_TRACE_ENTRY();
 
     if (_isVirtual) {
-        return false;
+        return _app->MainWindow.IsFullscreen();
     }
 
     if (_app->_ctx->ActiveRendererType != RenderType::Null) {
@@ -2198,8 +2187,7 @@ auto AppWindow::ToggleFullscreen(bool enable) -> bool
     FO_NON_CONST_METHOD_HINT();
 
     if (_isVirtual) {
-        ignore_unused(enable);
-        return false;
+        return _app->MainWindow.ToggleFullscreen(enable);
     }
 
     if (_app->_ctx->ActiveRendererType == RenderType::Null) {
@@ -2210,14 +2198,17 @@ auto AppWindow::ToggleFullscreen(bool enable) -> bool
     }
 
     const auto is_fullscreen = IsFullscreen();
+    auto* sdl_window = static_cast<SDL_Window*>(ResolveWindowHandle());
 
     if (!is_fullscreen && enable) {
-        if (SDL_SetWindowFullscreen(static_cast<SDL_Window*>(ResolveWindowHandle()), true)) {
+        if (SDL_SetWindowFullscreen(sdl_window, true)) {
+            SDL_SyncWindow(sdl_window);
             return IsFullscreen();
         }
     }
     else if (is_fullscreen && !enable) {
-        if (SDL_SetWindowFullscreen(static_cast<SDL_Window*>(ResolveWindowHandle()), false)) {
+        if (SDL_SetWindowFullscreen(sdl_window, false)) {
+            SDL_SyncWindow(sdl_window);
             return !IsFullscreen();
         }
     }
@@ -2231,7 +2222,12 @@ void AppWindow::Blink()
 
     FO_NON_CONST_METHOD_HINT();
 
-    if (_isVirtual || _app->_ctx->ActiveRendererType == RenderType::Null) {
+    if (_isVirtual) {
+        _app->MainWindow.Blink();
+        return;
+    }
+
+    if (_app->_ctx->ActiveRendererType == RenderType::Null) {
         return;
     }
 
@@ -2245,6 +2241,7 @@ void AppWindow::AlwaysOnTop(bool enable)
     FO_NON_CONST_METHOD_HINT();
 
     if (_isVirtual) {
+        _app->MainWindow.AlwaysOnTop(enable);
         return;
     }
 
@@ -2334,7 +2331,7 @@ void AppRender::SetRenderTarget(RenderTexture* tex)
     // While a virtual window is active, redirect the implicit "back buffer" target (nullptr)
     // to the window's offscreen texture so the existing render-target stack walks back into it.
     if (tex == nullptr) {
-        if (auto* virt = _app->_currentRenderingWindow.get_no_const(); virt != nullptr && virt->IsVirtual()) {
+        if (auto* virt = _app->_currentRenderingWindow.get(); virt != nullptr && virt->IsVirtual()) {
             if (auto* virt_tex = virt->GetRenderTexture(); virt_tex != nullptr) {
                 tex = virt_tex;
             }
@@ -2531,7 +2528,7 @@ void AppInput::SetScreenKeyboardEnabled(bool enabled)
         return;
     }
 
-    auto* window = static_cast<SDL_Window*>(_app->MainWindow._windowHandle.get_no_const());
+    auto* window = static_cast<SDL_Window*>(_app->MainWindow._windowHandle.get());
     const bool text_input_active = SDL_TextInputActive(window);
 
     if (text_input_active == enabled) {

--- a/Source/Scripting/ClientGlobalScriptMethods.cpp
+++ b/Source/Scripting/ClientGlobalScriptMethods.cpp
@@ -1298,7 +1298,8 @@ FO_SCRIPT_API void Client_Game_ActivateOffscreenSurface(ClientEngine* client, bo
     }
 
     if (client->OffscreenSurfaces.empty()) {
-        auto* rt = client->SprMngr.GetRtMngr().CreateRenderTarget(false, RenderTarget::SizeKindType::Screen, {0, 0}, false);
+        const auto window_size = client->SprMngr.GetWindow().GetSize();
+        auto* rt = client->SprMngr.GetRtMngr().CreateRenderTarget(false, window_size, false);
 
         if (rt == nullptr) {
             throw ScriptException("Can't create offscreen surface");

--- a/Source/Scripting/ClientMapScriptMethods.cpp
+++ b/Source/Scripting/ClientMapScriptMethods.cpp
@@ -139,6 +139,18 @@ FO_SCRIPT_API void Client_Map_RebuildFog(MapView* self)
 }
 
 ///@ ExportMethod
+FO_SCRIPT_API isize32 Client_Map_GetScreenSize(MapView* self)
+{
+    return self->GetScreenSize();
+}
+
+///@ ExportMethod
+FO_SCRIPT_API void Client_Map_SetScreenSize(MapView* self, isize32 size)
+{
+    self->SetScreenSize(size);
+}
+
+///@ ExportMethod
 FO_SCRIPT_API bool Client_Map_IsScrollCheck(MapView* self)
 {
     return self->IsScrollCheck();

--- a/Source/Scripting/ServerCritterScriptMethods.cpp
+++ b/Source/Scripting/ServerCritterScriptMethods.cpp
@@ -289,30 +289,6 @@ FO_SCRIPT_API void Server_Critter_RefreshView(Critter* self)
 }
 
 ///@ ExportMethod
-FO_SCRIPT_API void Server_Critter_ViewMap(Critter* self, Map* map, int32_t look, mpos hex, mdir dir)
-{
-    if (map == nullptr) {
-        throw ScriptException("Map arg is null");
-    }
-    if (!map->GetSize().is_valid_pos(hex)) {
-        throw ScriptException("Invalid hexes args");
-    }
-
-    if (!self->GetControlledByPlayer()) {
-        return;
-    }
-
-    auto look_ = look;
-
-    if (look_ == 0) {
-        look_ = self->GetLookDistance();
-    }
-
-    self->SetViewMap({.MapId = map->GetId(), .MapPid = map->GetProtoId(), .Look = numeric_cast<uint16_t>(look_), .Hex = hex, .Dir = dir});
-    self->Send_LoadMap(map);
-}
-
-///@ ExportMethod
 FO_SCRIPT_API void Server_Critter_SetDir(Critter* self, mdir dir)
 {
     if (dir == self->GetDir()) {

--- a/Source/Scripting/ServerPlayerScriptMethods.cpp
+++ b/Source/Scripting/ServerPlayerScriptMethods.cpp
@@ -83,4 +83,40 @@ FO_SCRIPT_API Critter* Server_Player_GetControlledCritter(Player* self)
     return self->GetControlledCritter();
 }
 
+///@ ExportMethod
+FO_SCRIPT_API void Server_Player_ViewMap(Player* self, Map* map, mpos hex)
+{
+    if (map == nullptr) {
+        throw ScriptException("Map arg is null");
+    }
+    if (self->GetControlledCritter() != nullptr) {
+        throw ScriptException("Player controls critter");
+    }
+    if (!map->GetSize().is_valid_pos(hex)) {
+        throw ScriptException("Invalid hexes args");
+    }
+
+    self->SetViewMap(map, hex);
+    self->Send_LoadMap(map);
+    self->GetEngine()->MapMngr.ViewMap(self, map);
+    self->Send_ViewMap();
+    self->Send_PlaceToGameComplete();
+}
+
+///@ ExportMethod
+FO_SCRIPT_API void Server_Player_ResetViewMap(Player* self)
+{
+    self->ResetViewMap();
+}
+
+///@ ExportMethod
+FO_SCRIPT_API void Server_Player_UnloadMap(Player* self)
+{
+    if (self->GetControlledCritter() != nullptr) {
+        throw ScriptException("Player controls critter");
+    }
+
+    self->Send_LoadMap(nullptr);
+}
+
 FO_END_NAMESPACE

--- a/Source/Scripting/ServerPlayerScriptMethods.cpp
+++ b/Source/Scripting/ServerPlayerScriptMethods.cpp
@@ -116,6 +116,7 @@ FO_SCRIPT_API void Server_Player_UnloadMap(Player* self)
         throw ScriptException("Player controls critter");
     }
 
+    self->ResetViewMap();
     self->Send_LoadMap(nullptr);
 }
 

--- a/Source/Server/Critter.cpp
+++ b/Source/Server/Critter.cpp
@@ -55,6 +55,25 @@ Critter::Critter(ServerEngine* engine, ident_t id, const ProtoCritter* proto, co
 Critter::~Critter()
 {
     FO_STACK_TRACE_ENTRY();
+
+    if (!_engine->IsShutdownInProgress()) {
+        FO_RUNTIME_VERIFY(!_player);
+        FO_RUNTIME_VERIFY(!GetMapId());
+        FO_RUNTIME_VERIFY(!GetIsAttached());
+        FO_RUNTIME_VERIFY(_invItems.empty());
+        FO_RUNTIME_VERIFY(_attachedCritters.empty());
+        FO_RUNTIME_VERIFY(!_globalMapGroup);
+        FO_RUNTIME_VERIFY(_visibleCrWhoSeeMe.empty());
+        FO_RUNTIME_VERIFY(_visibleCr.empty());
+        FO_RUNTIME_VERIFY(_visibleCrWhoSeeMeMap.empty());
+        FO_RUNTIME_VERIFY(_visibleCrMap.empty());
+        FO_RUNTIME_VERIFY(_visibleCrModes.empty());
+        FO_RUNTIME_VERIFY(_visibleCrGroup1.empty());
+        FO_RUNTIME_VERIFY(_visibleCrGroup2.empty());
+        FO_RUNTIME_VERIFY(_visibleCrGroup3.empty());
+        FO_RUNTIME_VERIFY(_visibleItems.empty());
+        FO_RUNTIME_VERIFY(_lockMapTransfers == 0);
+    }
 }
 
 auto Critter::GetName() const noexcept -> string_view
@@ -123,6 +142,10 @@ void Critter::MarkIsForPlayer()
 
     SetControlledByPlayer(true);
     _playerDetachTime = _engine->GameTime.GetFrameTime();
+
+    if (auto* map = _engine->EntityMngr.GetMap(GetMapId()); map != nullptr) {
+        map->RefreshCritterPlayerState(this);
+    }
 }
 
 void Critter::UnmarkIsForPlayer()
@@ -133,6 +156,10 @@ void Critter::UnmarkIsForPlayer()
     FO_RUNTIME_ASSERT(!_player);
 
     SetControlledByPlayer(false);
+
+    if (auto* map = _engine->EntityMngr.GetMap(GetMapId()); map != nullptr) {
+        map->RefreshCritterPlayerState(this);
+    }
 }
 
 void Critter::AttachPlayer(Player* player)
@@ -143,6 +170,7 @@ void Critter::AttachPlayer(Player* player)
     FO_RUNTIME_ASSERT(player);
     FO_RUNTIME_ASSERT(!player->GetControlledCritterId());
     FO_RUNTIME_ASSERT(!_player);
+    FO_RUNTIME_ASSERT(!player->GetViewMap());
 
     _player = player;
 
@@ -193,13 +221,6 @@ void Critter::StopMoving(MovingState reason)
     _moving.reset();
     _movingUid++;
     SetMovingSpeed(0);
-}
-
-void Critter::SetViewMap(ViewMapContext ctx)
-{
-    FO_STACK_TRACE_ENTRY();
-
-    _viewMap = SafeAlloc::MakeUnique<ViewMapContext>(std::move(ctx));
 }
 
 void Critter::AttachToCritter(Critter* cr)
@@ -714,6 +735,19 @@ auto Critter::CountInvItemByPid(hstring pid) const noexcept -> int32_t
     return count;
 }
 
+auto Critter::GetMapSpectators() -> ref_hold_vector<Player*>
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    if (const auto map_id = GetMapId()) {
+        if (auto* map = GetEngine()->EntityMngr.GetMap(map_id); map != nullptr && map->HasSpectatorPlayers()) {
+            return copy_hold_ref(map->GetSpectatorPlayers());
+        }
+    }
+
+    return ref_hold_vector<Player*>(0);
+}
+
 void Critter::Broadcast_Property(NetProperty type, const Property* prop, const ServerEntity* entity)
 {
     FO_STACK_TRACE_ENTRY();
@@ -722,6 +756,10 @@ void Critter::Broadcast_Property(NetProperty type, const Property* prop, const S
 
     for (auto& cr : _visibleCrWhoSeeMe) {
         cr->Send_Property(type, prop, entity);
+    }
+
+    for (auto* player : GetMapSpectators()) {
+        player->Send_Property(type, prop, entity);
     }
 }
 
@@ -734,6 +772,10 @@ void Critter::Broadcast_Action(CritterAction action, int32_t action_data, const 
     for (auto& cr : _visibleCrWhoSeeMe) {
         cr->Send_Action(this, action, action_data, item);
     }
+
+    for (auto* player : GetMapSpectators()) {
+        player->Send_Action(this, action, action_data, item);
+    }
 }
 
 void Critter::Broadcast_Dir()
@@ -744,6 +786,10 @@ void Critter::Broadcast_Dir()
 
     for (auto& cr : _visibleCrWhoSeeMe) {
         cr->Send_Dir(this);
+    }
+
+    for (auto* player : GetMapSpectators()) {
+        player->Send_Dir(this);
     }
 }
 
@@ -756,19 +802,31 @@ void Critter::Broadcast_Teleport(mpos to_hex)
     for (auto& cr : _visibleCrWhoSeeMe) {
         cr->Send_Teleport(this, to_hex);
     }
+
+    for (auto* player : GetMapSpectators()) {
+        player->Send_Teleport(this, to_hex);
+    }
 }
 
-void Critter::SendAndBroadcast(const Player* ignore_player, const function<void(Critter*)>& callback)
+void Critter::SendAndBroadcast(const Player* ignore_player, const function<void(Critter*)>& cr_callback, const function<void(Player*)>& spectator_callback)
 {
     FO_STACK_TRACE_ENTRY();
 
     if (ignore_player == nullptr || ignore_player != GetPlayer()) {
-        callback(this);
+        cr_callback(this);
     }
 
     for (auto& cr : _visibleCrWhoSeeMe) {
         if (ignore_player == nullptr || ignore_player != cr->GetPlayer()) {
-            callback(cr.get());
+            cr_callback(cr.get());
+        }
+    }
+
+    if (spectator_callback) {
+        for (auto* player : GetMapSpectators()) {
+            if (player != ignore_player) {
+                spectator_callback(player);
+            }
         }
     }
 }
@@ -782,6 +840,10 @@ void Critter::SendAndBroadcast_Moving()
     for (auto& cr : _visibleCrWhoSeeMe) {
         cr->Send_Moving(this);
     }
+
+    for (auto* player : GetMapSpectators()) {
+        player->Send_Moving(this);
+    }
 }
 
 void Critter::SendAndBroadcast_Action(CritterAction action, int32_t action_data, const Item* context_item)
@@ -792,6 +854,10 @@ void Critter::SendAndBroadcast_Action(CritterAction action, int32_t action_data,
 
     for (auto& cr : _visibleCrWhoSeeMe) {
         cr->Send_Action(this, action, action_data, context_item);
+    }
+
+    for (auto* player : GetMapSpectators()) {
+        player->Send_Action(this, action, action_data, context_item);
     }
 }
 
@@ -804,6 +870,10 @@ void Critter::SendAndBroadcast_MoveItem(const Item* item, CritterAction action, 
     for (auto& cr : _visibleCrWhoSeeMe) {
         cr->Send_MoveItem(this, item, action, prev_slot);
     }
+
+    for (auto* player : GetMapSpectators()) {
+        player->Send_MoveItem(this, item, action, prev_slot);
+    }
 }
 
 void Critter::SendAndBroadcast_Attachments()
@@ -814,6 +884,10 @@ void Critter::SendAndBroadcast_Attachments()
 
     for (auto& cr : _visibleCrWhoSeeMe) {
         cr->Send_Attachments(this);
+    }
+
+    for (auto* player : GetMapSpectators()) {
+        player->Send_Attachments(this);
     }
 }
 
@@ -967,15 +1041,6 @@ void Critter::Send_MoveItem(const Critter* from_cr, const Item* item, CritterAct
 
     if (_player) {
         _player->Send_MoveItem(from_cr, item, action, prev_slot);
-    }
-}
-
-void Critter::Send_ViewMap()
-{
-    FO_STACK_TRACE_ENTRY();
-
-    if (_player) {
-        _player->Send_ViewMap();
     }
 }
 

--- a/Source/Server/Critter.h
+++ b/Source/Server/Critter.h
@@ -49,17 +49,6 @@ class Item;
 class Map;
 class Location;
 
-struct ViewMapContext
-{
-    ident_t MapId {};
-    hstring MapPid {};
-    uint16_t Look {};
-    mpos Hex {};
-    mdir Dir {};
-    ident_t LocId {};
-    int32_t LocEnt {};
-};
-
 class Critter final : public ServerEntity, public EntityWithProto, public CritterProperties
 {
 public:
@@ -102,7 +91,6 @@ public:
     [[nodiscard]] auto GetMovingContext() noexcept -> MovingContext* { return _moving ? _moving.get() : _lastMoving.get(); }
     [[nodiscard]] auto GetMovingState() const noexcept -> MovingState { return _moving ? MovingState::InProgress : (_lastMoving ? _lastMoving->GetCompleteReason() : MovingState::Success); }
     [[nodiscard]] auto IsMapTransfersLocked() const noexcept -> bool { return _lockMapTransfers != 0; }
-    [[nodiscard]] auto GetViewMap() const noexcept -> const ViewMapContext* { return _viewMap.get(); }
     [[nodiscard]] auto HasAttachedCritters() const noexcept -> bool { return !_attachedCritters.empty(); }
     [[nodiscard]] auto GetAttachedCritters() noexcept -> span<raw_ptr<Critter>> { return _attachedCritters; }
     [[nodiscard]] auto GetAttachedCritters() const noexcept -> const_span<raw_ptr<Critter>> { return _attachedCritters; }
@@ -137,15 +125,13 @@ public:
     void ChangeDir(mdir dir);
     void LockMapTransfers() noexcept { _lockMapTransfers++; }
     void UnlockMapTransfers() noexcept { _lockMapTransfers--; }
-    void SetViewMap(ViewMapContext ctx);
-    void ResetViewMap() noexcept { _viewMap.reset(); }
 
     void Broadcast_Property(NetProperty type, const Property* prop, const ServerEntity* entity);
     void Broadcast_Action(CritterAction action, int32_t action_data, const Item* item);
     void Broadcast_Dir();
     void Broadcast_Teleport(mpos to_hex);
 
-    void SendAndBroadcast(const Player* ignore_player, const function<void(Critter*)>& callback);
+    void SendAndBroadcast(const Player* ignore_player, const function<void(Critter*)>& cr_callback, const function<void(Player*)>& spectator_callback = {});
     void SendAndBroadcast_Moving();
     void SendAndBroadcast_Action(CritterAction action, int32_t action_data, const Item* context_item);
     void SendAndBroadcast_MoveItem(const Item* item, CritterAction action, CritterItemSlot prev_slot);
@@ -168,7 +154,6 @@ public:
     void Send_InfoMessage(EngineInfoMessage info_message, string_view extra_text = "");
     void Send_Action(const Critter* from_cr, CritterAction action, int32_t action_data, const Item* context_item);
     void Send_MoveItem(const Critter* from_cr, const Item* item, CritterAction action, CritterItemSlot prev_slot);
-    void Send_ViewMap();
     void Send_PlaceToGameComplete();
     void Send_SomeItems(const_span<Item*> items, bool owned, bool with_inner_entities, const any_t& context_param);
     void Send_Attachments(const Critter* from_cr);
@@ -205,6 +190,8 @@ public:
     FO_ENTITY_EVENT(OnBarter, Critter* /*playerCr*/, bool /*begin*/, int32_t /*barterCount*/);
 
 private:
+    auto GetMapSpectators() -> ref_hold_vector<Player*>;
+
     uint32_t _movingUid {};
     refcount_ptr<MovingContext> _moving {};
     refcount_ptr<MovingContext> _lastMoving {};
@@ -222,7 +209,6 @@ private:
     unordered_set<ident_t> _visibleItems {};
     shared_ptr<vector<raw_ptr<Critter>>> _globalMapGroup {};
     int32_t _lockMapTransfers {};
-    unique_ptr<ViewMapContext> _viewMap {};
     vector<raw_ptr<Critter>> _attachedCritters {};
 };
 

--- a/Source/Server/Item.cpp
+++ b/Source/Server/Item.cpp
@@ -46,6 +46,15 @@ Item::Item(ServerEngine* engine, ident_t id, const ProtoItem* proto, const Prope
     FO_STACK_TRACE_ENTRY();
 }
 
+Item::~Item()
+{
+    FO_STACK_TRACE_ENTRY();
+
+    if (!_engine->IsShutdownInProgress()) {
+        FO_RUNTIME_VERIFY(!HasInnerItems());
+    }
+}
+
 auto Item::GetInnerItem(ident_t item_id) noexcept -> Item*
 {
     FO_STACK_TRACE_ENTRY();

--- a/Source/Server/Item.h
+++ b/Source/Server/Item.h
@@ -57,7 +57,7 @@ public:
     Item(Item&&) noexcept = delete;
     auto operator=(const Item&) = delete;
     auto operator=(Item&&) noexcept = delete;
-    ~Item() override = default;
+    ~Item() override;
 
     [[nodiscard]] auto GetName() const noexcept -> string_view override { return _proto->GetName(); }
     [[nodiscard]] auto GetProtoItem() const noexcept -> const ProtoItem* { return static_cast<const ProtoItem*>(_proto.get()); }

--- a/Source/Server/Location.cpp
+++ b/Source/Server/Location.cpp
@@ -46,6 +46,15 @@ Location::Location(ServerEngine* engine, ident_t id, const ProtoLocation* proto,
     FO_STACK_TRACE_ENTRY();
 }
 
+Location::~Location()
+{
+    FO_STACK_TRACE_ENTRY();
+
+    if (!_engine->IsShutdownInProgress()) {
+        FO_RUNTIME_VERIFY(_locMaps.empty());
+    }
+}
+
 auto Location::GetMapByIndex(int32_t index) noexcept -> Map*
 {
     FO_STACK_TRACE_ENTRY();

--- a/Source/Server/Location.h
+++ b/Source/Server/Location.h
@@ -53,7 +53,7 @@ public:
     Location(Location&&) noexcept = delete;
     auto operator=(const Location&) = delete;
     auto operator=(Location&&) noexcept = delete;
-    ~Location() override = default;
+    ~Location() override;
 
     [[nodiscard]] auto GetName() const noexcept -> string_view override { return _proto->GetName(); }
     [[nodiscard]] auto GetProtoLoc() const noexcept -> const ProtoLocation* { return static_cast<const ProtoLocation*>(_proto.get()); }

--- a/Source/Server/Map.cpp
+++ b/Source/Server/Map.cpp
@@ -36,6 +36,7 @@
 #include "CritterManager.h"
 #include "Item.h"
 #include "Location.h"
+#include "Player.h"
 #include "Server.h"
 #include "Settings.h"
 
@@ -65,6 +66,32 @@ Map::Map(ServerEngine* engine, ident_t id, const ProtoMap* proto, Location* loca
 Map::~Map()
 {
     FO_STACK_TRACE_ENTRY();
+
+    if (!_engine->IsShutdownInProgress()) {
+        FO_RUNTIME_VERIFY(_spectatorPlayers.empty());
+        FO_RUNTIME_VERIFY(_critters.empty());
+        FO_RUNTIME_VERIFY(_crittersMap.empty());
+        FO_RUNTIME_VERIFY(_playerCritters.empty());
+        FO_RUNTIME_VERIFY(_nonPlayerCritters.empty());
+        FO_RUNTIME_VERIFY(_items.empty());
+        FO_RUNTIME_VERIFY(_itemsMap.empty());
+    }
+}
+
+void Map::AddSpectatorPlayer(Player* player)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    FO_RUNTIME_ASSERT(player);
+    vec_add_unique_value(_spectatorPlayers, player);
+}
+
+void Map::RemoveSpectatorPlayer(Player* player)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    FO_RUNTIME_ASSERT(player);
+    vec_remove_unique_value(_spectatorPlayers, player);
 }
 
 void Map::SetLocation(Location* loc) noexcept
@@ -164,6 +191,34 @@ void Map::RemoveCritter(Critter* cr)
     }
 }
 
+void Map::RefreshCritterPlayerState(Critter* cr)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    FO_RUNTIME_ASSERT(cr);
+    FO_RUNTIME_ASSERT(_crittersMap.count(cr->GetId()));
+
+    const bool removed_from_players = vec_safe_remove_unique_value(_playerCritters, cr);
+    const bool removed_from_non_players = vec_safe_remove_unique_value(_nonPlayerCritters, cr);
+    FO_RUNTIME_ASSERT(removed_from_players || removed_from_non_players);
+
+    auto cr_ids = GetCritterIds();
+    vec_safe_remove_unique_value(cr_ids, cr->GetId());
+
+    if (!cr->GetControlledByPlayer()) {
+        vec_add_unique_value(cr_ids, cr->GetId());
+    }
+
+    SetCritterIds(cr_ids);
+
+    if (cr->GetControlledByPlayer()) {
+        vec_add_unique_value(_playerCritters, cr);
+    }
+    else {
+        vec_add_unique_value(_nonPlayerCritters, cr);
+    }
+}
+
 void Map::AddCritterToField(Critter* cr)
 {
     FO_STACK_TRACE_ENTRY();
@@ -252,6 +307,11 @@ void Map::AddItem(Item* item, mpos hex, Critter* dropper)
             cr->Send_AddItemOnMap(item);
             cr->OnItemOnMapAppeared.Fire(item, dropper);
         }
+    }
+
+    // Notify spectators
+    for (auto* player : copy_hold_ref(_spectatorPlayers)) {
+        player->Send_AddItemOnMap(item);
     }
 }
 
@@ -359,6 +419,11 @@ void Map::RemoveItem(ident_t item_id)
             cr->OnItemOnMapDisappeared.Fire(item, nullptr);
         }
     }
+
+    // Notify spectators
+    for (auto* player : copy_hold_ref(_spectatorPlayers)) {
+        player->Send_RemoveItemFromMap(item);
+    }
 }
 
 void Map::SendProperty(NetProperty type, const Property* prop, ServerEntity* entity)
@@ -372,6 +437,10 @@ void Map::SendProperty(NetProperty type, const Property* prop, ServerEntity* ent
         for (auto& cr : GetCritters()) {
             cr->Send_Property(type, prop, entity);
         }
+
+        for (auto* player : copy_hold_ref(_spectatorPlayers)) {
+            player->Send_Property(type, prop, entity);
+        }
     }
     else if (type == NetProperty::MapItem) {
         auto* item = dynamic_cast<Item*>(entity);
@@ -382,6 +451,10 @@ void Map::SendProperty(NetProperty type, const Property* prop, ServerEntity* ent
                 cr->Send_Property(type, prop, entity);
                 cr->OnItemOnMapChanged.Fire(item);
             }
+        }
+
+        for (auto* player : copy_hold_ref(_spectatorPlayers)) {
+            player->Send_Property(type, prop, entity);
         }
     }
     else {

--- a/Source/Server/Map.h
+++ b/Source/Server/Map.h
@@ -50,6 +50,7 @@ class StaticItem;
 class Critter;
 class Map;
 class Location;
+class Player;
 
 struct StaticMap
 {
@@ -113,6 +114,9 @@ public:
     [[nodiscard]] auto GetPlayerCritters() noexcept -> span<raw_ptr<Critter>> { return _playerCritters; }
     [[nodiscard]] auto GetNonPlayerCritters() noexcept -> span<raw_ptr<Critter>> { return _nonPlayerCritters; }
     [[nodiscard]] auto IsTriggerStaticItemOnHex(mpos hex) const noexcept -> bool;
+    [[nodiscard]] auto HasSpectatorPlayers() const noexcept -> bool { return !_spectatorPlayers.empty(); }
+    [[nodiscard]] auto GetSpectatorPlayers() noexcept -> span<raw_ptr<Player>> { return _spectatorPlayers; }
+    [[nodiscard]] auto GetSpectatorPlayers() const noexcept -> const_span<raw_ptr<Player>> { return _spectatorPlayers; }
     [[nodiscard]] auto GetStaticItem(ident_t id) noexcept -> StaticItem*;
     [[nodiscard]] auto GetStaticItemOnHex(mpos hex, hstring pid) noexcept -> StaticItem*;
     [[nodiscard]] auto GetStaticItems() noexcept -> span<raw_ptr<StaticItem>> { return _staticMap->StaticItems; }
@@ -125,6 +129,9 @@ public:
     void SetLocation(Location* loc) noexcept;
     void AddCritter(Critter* cr);
     void RemoveCritter(Critter* cr);
+    void RefreshCritterPlayerState(Critter* cr);
+    void AddSpectatorPlayer(Player* player);
+    void RemoveSpectatorPlayer(Player* player);
     void AddItem(Item* item, mpos hex, Critter* dropper);
     void SetItem(Item* item);
     void RemoveItem(ident_t item_id);
@@ -174,6 +181,7 @@ private:
     vector<raw_ptr<Item>> _items {};
     unordered_map<ident_t, raw_ptr<Item>> _itemsMap {};
     raw_ptr<Location> _mapLocation {};
+    vector<raw_ptr<Player>> _spectatorPlayers {};
 };
 
 FO_END_NAMESPACE

--- a/Source/Server/MapManager.cpp
+++ b/Source/Server/MapManager.cpp
@@ -36,6 +36,7 @@
 #include "EntityManager.h"
 #include "ItemManager.h"
 #include "LineTracer.h"
+#include "Player.h"
 #include "ProtoManager.h"
 #include "Server.h"
 #include "Settings.h"
@@ -610,6 +611,13 @@ void MapManager::DestroyMapInternal(Map* map)
 {
     FO_STACK_TRACE_ENTRY();
 
+    // Eject spectators before destroying map content so each spectator gets a clean LoadMap(nullptr) and clears its ViewMap.
+    while (map->HasSpectatorPlayers()) {
+        auto* player = map->GetSpectatorPlayers().back().get();
+        player->ResetViewMap();
+        player->Send_LoadMap(nullptr);
+    }
+
     for (InfinityLoopDetector detector; map->HasCritters() || map->HasItems() || map->HasInnerEntities(); detector.AddLoop()) {
         try {
             if (map->HasCritters() || map->HasItems()) {
@@ -938,6 +946,13 @@ void MapManager::AddCritterToMap(Critter* cr, Map* map, mpos hex, mdir dir, iden
         }
 
         map->AddCritter(cr);
+
+        // Notify spectators
+        if (map->HasSpectatorPlayers()) {
+            for (auto* player : copy_hold_ref(map->GetSpectatorPlayers())) {
+                player->Send_AddCritter(cr);
+            }
+        }
     }
     else {
         auto& cr_group = cr->GetRawGlobalMapGroup();
@@ -994,6 +1009,14 @@ void MapManager::RemoveCritterFromMap(Critter* cr, Map* map)
         }
 
         cr->ClearVisibleEnitites();
+
+        // Notify spectators
+        if (map->HasSpectatorPlayers()) {
+            for (auto* player : copy_hold_ref(map->GetSpectatorPlayers())) {
+                player->Send_RemoveCritter(cr);
+            }
+        }
+
         map->RemoveCritter(cr);
         cr->SetMapId({});
 
@@ -1197,37 +1220,29 @@ void MapManager::ProcessVisibleItems(Critter* cr)
     }
 }
 
-void MapManager::ViewMap(Critter* view_cr, Map* map, int32_t look, mpos hex, mdir dir)
+void MapManager::ViewMap(Player* view_player, Map* map)
 {
     FO_STACK_TRACE_ENTRY();
 
-    // Critters
-    ignore_unused(look);
-    ignore_unused(hex);
-    ignore_unused(dir);
+    FO_RUNTIME_ASSERT(view_player);
+    FO_RUNTIME_ASSERT(map);
 
+    // Critters: spectator sees every non-destroyed critter on the map
     for (const auto* cr : copy_hold_ref(map->GetCritters())) {
         if (cr->IsDestroyed()) {
             continue;
         }
-        if (cr == view_cr) {
-            continue;
-        }
 
-        if (CheckCritterVisibilityHook(_engine.get(), map, view_cr, cr) != CritterVisibilityMode::None) {
-            view_cr->Send_AddCritter(cr);
-        }
+        view_player->Send_AddCritter(cr);
     }
 
-    // Items
+    // Items: spectator sees every non-destroyed item on the map
     for (const auto* item : copy_hold_ref(map->GetItems())) {
         if (item->IsDestroyed()) {
             continue;
         }
 
-        if (view_cr->CanSeeItemOnMap(item)) {
-            view_cr->Send_AddItemOnMap(item);
-        }
+        view_player->Send_AddItemOnMap(item);
     }
 }
 

--- a/Source/Server/MapManager.h
+++ b/Source/Server/MapManager.h
@@ -51,6 +51,7 @@ class ProtoManager;
 class EntityManager;
 class ItemManager;
 class CritterManager;
+class Player;
 
 struct TraceResult
 {
@@ -94,8 +95,7 @@ public:
     void TransferToGlobal(Critter* cr, ident_t global_cr_id);
     void ProcessVisibleCritters(Critter* cr);
     void ProcessVisibleItems(Critter* cr);
-    void ViewMap(Critter* view_cr, Map* map, int32_t look, mpos hex, mdir dir);
-    void ViewMap(Critter* view_cr, Map* map, int32_t look, mpos hex, hdir dir) { ViewMap(view_cr, map, look, hex, mdir(dir)); }
+    void ViewMap(Player* view_player, Map* map);
 
 private:
     auto IsCritterSeeCritter(const Map* map, const Critter* cr, const Critter* target) const -> CritterVisibilityMode;

--- a/Source/Server/Player.cpp
+++ b/Source/Server/Player.cpp
@@ -54,6 +54,14 @@ Player::Player(ServerEngine* engine, ident_t id, unique_ptr<ServerConnection> co
 Player::~Player()
 {
     FO_STACK_TRACE_ENTRY();
+
+    if (!_engine->IsShutdownInProgress()) {
+        FO_RUNTIME_VERIFY(!_controlledCr);
+        FO_RUNTIME_VERIFY(!_viewMap);
+        FO_RUNTIME_VERIFY(!_viewMapTarget);
+        FO_RUNTIME_VERIFY(!_sendIgnoreEntity);
+        FO_RUNTIME_VERIFY(!_sendIgnoreProperty);
+    }
 }
 
 void Player::SetName(string_view name)
@@ -95,6 +103,37 @@ void Player::SetIgnoreSendEntityProperty(const Entity* entity, const Property* p
 
     _sendIgnoreEntity = entity;
     _sendIgnoreProperty = prop;
+}
+
+void Player::SetViewMap(Map* map, mpos hex)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    FO_RUNTIME_ASSERT(!_controlledCr);
+    FO_RUNTIME_ASSERT(map);
+
+    if (_viewMapTarget != map) {
+        if (_viewMapTarget) {
+            _viewMapTarget->RemoveSpectatorPlayer(this);
+        }
+
+        _viewMapTarget = map;
+        _viewMapTarget->AddSpectatorPlayer(this);
+    }
+
+    _viewMap = SafeAlloc::MakeUnique<ViewMapContext>(ViewMapContext {.MapId = map->GetId(), .Hex = hex});
+}
+
+void Player::ResetViewMap() noexcept
+{
+    FO_STACK_TRACE_ENTRY();
+
+    if (_viewMapTarget) {
+        _viewMapTarget->RemoveSpectatorPlayer(this);
+        _viewMapTarget = nullptr;
+    }
+
+    _viewMap.reset();
 }
 
 void Player::Send_LoginSuccess()
@@ -466,16 +505,11 @@ void Player::Send_ViewMap()
 {
     FO_STACK_TRACE_ENTRY();
 
-    FO_RUNTIME_ASSERT(_controlledCr);
+    FO_RUNTIME_ASSERT(_viewMap);
 
     auto out_buf = _connection->WriteMsg(NetMessage::ViewMap);
 
-    const auto* view_map = _controlledCr->GetViewMap();
-    FO_RUNTIME_ASSERT(view_map);
-
-    out_buf->Write(view_map->Hex);
-    out_buf->Write(view_map->LocId);
-    out_buf->Write(view_map->LocEnt);
+    out_buf->Write(_viewMap->Hex);
 }
 
 void Player::Send_PlaceToGameComplete()

--- a/Source/Server/Player.h
+++ b/Source/Server/Player.h
@@ -49,6 +49,12 @@ class Map;
 class Location;
 class MapManager;
 
+struct ViewMapContext
+{
+    ident_t MapId {};
+    mpos Hex {};
+};
+
 class Player final : public ServerEntity, public PlayerProperties
 {
 public:
@@ -65,12 +71,17 @@ public:
     [[nodiscard]] auto GetControlledCritter() const noexcept -> const Critter* { return _controlledCr.get(); }
     [[nodiscard]] auto GetConnection() noexcept -> ServerConnection* { return _connection.get(); }
     [[nodiscard]] auto GetConnection() const noexcept -> const ServerConnection* { return _connection.get(); }
+    [[nodiscard]] auto GetViewMap() const noexcept -> const ViewMapContext* { return _viewMap.get(); }
+    [[nodiscard]] auto GetViewMapTarget() const noexcept -> const Map* { return _viewMapTarget.get(); }
+    [[nodiscard]] auto GetViewMapTarget() noexcept -> Map* { return _viewMapTarget.get(); }
 
     void SetName(string_view name);
     void SetControlledCritter(Critter* cr);
     void DetachCritter();
     void SwapConnection(Player* other) noexcept;
     void SetIgnoreSendEntityProperty(const Entity* entity, const Property* prop) noexcept;
+    void SetViewMap(Map* map, mpos hex);
+    void ResetViewMap() noexcept;
 
     void Send_LoginSuccess();
     void Send_Moving(const Critter* from_cr);
@@ -114,6 +125,8 @@ private:
     raw_ptr<Critter> _controlledCr {};
     raw_ptr<const Entity> _sendIgnoreEntity {};
     raw_ptr<const Property> _sendIgnoreProperty {};
+    unique_ptr<ViewMapContext> _viewMap {};
+    raw_ptr<Map> _viewMapTarget {};
 };
 
 FO_END_NAMESPACE

--- a/Source/Server/Server.cpp
+++ b/Source/Server/Server.cpp
@@ -712,6 +712,9 @@ void ServerEngine::Shutdown()
     }
 
     TimeEventMngr.ClearTimeEvents();
+
+    _shutdownInProgress = true;
+
     EntityMngr.DestroyInnerEntities(this);
     EntityMngr.DestroyAllEntities();
     ShutdownBackends();
@@ -1345,6 +1348,7 @@ void ServerEngine::ProcessPlayer(Player* player)
         OnPlayerLogout.Fire(player);
 
         player->DetachCritter();
+        player->ResetViewMap();
         player->MarkAsDestroyed();
         EntityMngr.UnregisterPlayer(player);
         return;
@@ -1961,12 +1965,22 @@ void ServerEngine::SwitchPlayerCritter(Player* player, Critter* cr)
 
     FO_RUNTIME_ASSERT(player);
     FO_RUNTIME_ASSERT(!player->IsDestroyed());
-    FO_RUNTIME_ASSERT(cr);
+
+    Critter* prev_cr = player->GetControlledCritter();
+
+    if (cr == nullptr) {
+        if (prev_cr == nullptr) {
+            return;
+        }
+
+        WriteLog(LogType::Info, "Detach player {} from critter {}", player->GetName(), prev_cr->GetName());
+        player->DetachCritter();
+        return;
+    }
+
     FO_RUNTIME_ASSERT(!cr->IsDestroyed());
 
     WriteLog(LogType::Info, "Switch player {} to critter {}", player->GetName(), cr->GetName());
-
-    Critter* prev_cr = player->GetControlledCritter();
 
     if (prev_cr == cr) {
         throw GenericException("Player critter already selected");
@@ -1974,6 +1988,8 @@ void ServerEngine::SwitchPlayerCritter(Player* player, Critter* cr)
     if (!cr->GetControlledByPlayer()) {
         throw GenericException("Critter can't be controlled by player");
     }
+
+    player->ResetViewMap();
 
     if (prev_cr != nullptr) {
         prev_cr->DetachPlayer();
@@ -2006,20 +2022,6 @@ void ServerEngine::DestroyUnloadedCritter(ident_t cr_id)
 void ServerEngine::SendCritterInitialInfo(Critter* cr, Critter* prev_cr)
 {
     cr->Send_TimeSync();
-
-    if (const auto* view_map = cr->GetViewMap(); view_map != nullptr) {
-        auto* map = EntityMngr.GetMap(view_map->MapId);
-
-        if (map != nullptr) {
-            MapMngr.ViewMap(cr, map, view_map->Look, view_map->Hex, view_map->Dir);
-            cr->Send_ViewMap();
-            cr->Send_TimeSync();
-            cr->ResetViewMap();
-            return;
-        }
-
-        cr->ResetViewMap();
-    }
 
     const auto* map = EntityMngr.GetMap(cr->GetMapId());
     const bool same_map = prev_cr != nullptr && prev_cr->GetMapId() == cr->GetMapId();
@@ -2243,6 +2245,7 @@ auto ServerEngine::LoginPlayerToNewRecord(Player* unlogined_player) -> Player*
         }
         if (registered_player) {
             safe_call([&] { player->DetachCritter(); });
+            safe_call([&] { player->ResetViewMap(); });
             safe_call([&] { player->MarkAsDestroyed(); });
             safe_call([&] { EntityMngr.UnregisterPlayer(player); });
         }
@@ -2264,6 +2267,7 @@ auto ServerEngine::LoginPlayerToNewRecord(Player* unlogined_player) -> Player*
         DbStorage.Delete(PlayersCollectionName, player->GetId());
         inserted_player_record = false;
         player->DetachCritter();
+        player->ResetViewMap();
         player->MarkAsDestroyed();
         EntityMngr.UnregisterPlayer(player);
         registered_player = false;
@@ -2295,6 +2299,7 @@ auto ServerEngine::LoginPlayerToExistentRecord(Player* unlogined_player, ident_t
     scope_fail disconnect_on_error {[&]() noexcept {
         if (registered_player) {
             safe_call([&] { unlogined_player->DetachCritter(); });
+            safe_call([&] { unlogined_player->ResetViewMap(); });
             safe_call([&] { unlogined_player->MarkAsDestroyed(); });
             safe_call([&] { EntityMngr.UnregisterPlayer(unlogined_player); });
         }
@@ -2327,6 +2332,7 @@ auto ServerEngine::LoginPlayerToExistentRecord(Player* unlogined_player, ident_t
 
         if (OnPlayerLogin.Fire(player, nullptr) == Entity::EventResult::StopChain) {
             player->DetachCritter();
+            player->ResetViewMap();
             player->MarkAsDestroyed();
             EntityMngr.UnregisterPlayer(player);
             registered_player = false;
@@ -2607,7 +2613,7 @@ void ServerEngine::Process_StopMove(Player* player)
         return;
     }
 
-    StopCritterMoving(cr, MovingState::Stopped, [&] { cr->SendAndBroadcast(player, [&](Critter* cr2) { cr2->Send_Moving(cr); }); });
+    StopCritterMoving(cr, MovingState::Stopped, [&] { cr->SendAndBroadcast(player, [&](Critter* cr2) { cr2->Send_Moving(cr); }, [cr](Player* p) { p->Send_Moving(cr); }); });
 }
 
 void ServerEngine::Process_Dir(Player* player)
@@ -2646,7 +2652,7 @@ void ServerEngine::Process_Dir(Player* player)
     }
 
     cr->ChangeDir(checked_dir);
-    cr->SendAndBroadcast(player, [cr](Critter* cr2) { cr2->Send_Dir(cr); });
+    cr->SendAndBroadcast(player, [cr](Critter* cr2) { cr2->Send_Dir(cr); }, [cr](Player* p) { p->Send_Dir(cr); });
 }
 
 void ServerEngine::Process_Property(Player* player)
@@ -3280,7 +3286,7 @@ void ServerEngine::StartCritterMoving(Critter* cr, refcount_ptr<MovingContext> m
     cr->GetMoving()->ValidateRuntimeState();
     cr->SetMovingSpeed(cr->GetMoving()->GetSpeed());
 
-    cr->SendAndBroadcast(initiator, [cr](Critter* cr2) { cr2->Send_Moving(cr); });
+    cr->SendAndBroadcast(initiator, [cr](Critter* cr2) { cr2->Send_Moving(cr); }, [cr](Player* p) { p->Send_Moving(cr); });
 
     OnCritterStartMoving.Fire(cr, was_moving);
 }
@@ -3339,7 +3345,7 @@ void ServerEngine::ChangeCritterMovingSpeed(Critter* cr, uint16_t speed)
     cr->GetMoving()->ChangeSpeed(speed, cur_time);
     cr->SetMovingSpeed(speed);
 
-    cr->SendAndBroadcast(nullptr, [cr](Critter* cr2) { cr2->Send_MovingSpeed(cr); });
+    cr->SendAndBroadcast(nullptr, [cr](Critter* cr2) { cr2->Send_MovingSpeed(cr); }, [cr](Player* p) { p->Send_MovingSpeed(cr); });
 
     OnCritterStartMoving.Fire(cr, true);
 }

--- a/Source/Server/Server.h
+++ b/Source/Server/Server.h
@@ -77,6 +77,7 @@ public:
 
     [[nodiscard]] auto IsStarted() const noexcept -> bool { return _started; }
     [[nodiscard]] auto IsStartingError() const noexcept -> bool { return _startingError; }
+    [[nodiscard]] auto IsShutdownInProgress() const noexcept -> bool { return _shutdownInProgress; }
     [[nodiscard]] auto GetHealthInfo() const -> string;
     [[nodiscard]] auto MakePlayerId(string_view player_name) const -> ident_t;
     [[nodiscard]] auto GetLangPack() const -> const TextPack& { return _defaultLang; }
@@ -288,6 +289,7 @@ private:
 
     std::atomic_bool _started {};
     std::atomic_bool _startingError {};
+    std::atomic_bool _shutdownInProgress {};
     FrameBalancer _loopBalancer {};
     ServerStats _stats {};
     vector<vector<uint8_t>> _updateFilesData {};

--- a/Source/Tests/Test_AngelScriptAttributes.cpp
+++ b/Source/Tests/Test_AngelScriptAttributes.cpp
@@ -154,15 +154,15 @@ namespace
 
     static void DummyEvent_Subscribe(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
     }
 
     static void DummyEvent_Unsubscribe(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
     }
 
     static void DummyRefAddRef(void* obj)
@@ -198,74 +198,74 @@ namespace
 
     static void DummyScheduler_StartTimeEvent(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
     }
 
     static void DummyScheduler_StartTimeEventRepeat(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
-        ignore_unused(gen->GetAddressOfArg(2));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
+        (void)gen->GetAddressOfArg(2);
     }
 
     static void DummyScheduler_StopTimeEvent(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
     }
 
     static void DummyScheduler_CountTimeEvent(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
         gen->SetReturnDWord(0);
     }
 
     static void DummyScheduler_RepeatTimeEvent(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
     }
 
     static void DummyScheduler_SetTimeEventData(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
     }
 
     static void DummyProperty_SetPropertyGetter(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
     }
 
     static void DummyProperty_AddPropertySetter(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
     }
 
     static void DummyProperty_AddPropertyDeferredSetter(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
     }
 
     static void DummyCritter_AddAnimCallback(asIScriptGeneric* gen)
     {
-        ignore_unused(gen->GetObject());
-        ignore_unused(gen->GetAddressOfArg(0));
-        ignore_unused(gen->GetAddressOfArg(1));
-        ignore_unused(gen->GetAddressOfArg(2));
-        ignore_unused(gen->GetAddressOfArg(3));
+        (void)gen->GetObject();
+        (void)gen->GetAddressOfArg(0);
+        (void)gen->GetAddressOfArg(1);
+        (void)gen->GetAddressOfArg(2);
+        (void)gen->GetAddressOfArg(3);
     }
 
     struct ScriptMessages

--- a/Source/Tests/Test_Properties.cpp
+++ b/Source/Tests/Test_Properties.cpp
@@ -227,10 +227,10 @@ namespace
 
             auto make_route_snapshot = [this]() {
                 auto fields_registrator = SafeAlloc::MakeUnique<PropertyRegistrator>("RouteSnapshotRefType", EngineSideKind::ServerSide, _proto_hashes, *this);
-                ignore_unused(fields_registrator->RegisterProperty({"Common", "int32[]", "Values"}));
-                ignore_unused(fields_registrator->RegisterProperty({"Common", "hstring[]", "Tags"}));
-                ignore_unused(fields_registrator->RegisterProperty({"Common", "Waypoint", "Anchor"}));
-                ignore_unused(fields_registrator->RegisterProperty({"Common", "string", "Note"}));
+                (void)fields_registrator->RegisterProperty({"Common", "int32[]", "Values"});
+                (void)fields_registrator->RegisterProperty({"Common", "hstring[]", "Tags"});
+                (void)fields_registrator->RegisterProperty({"Common", "Waypoint", "Anchor"});
+                (void)fields_registrator->RegisterProperty({"Common", "string", "Note"});
 
                 auto& ref_type = _ref_types["RouteSnapshot"];
                 ref_type.FieldsRegistrator = fields_registrator.get();
@@ -247,9 +247,9 @@ namespace
 
             auto make_route_envelope = [this]() {
                 auto fields_registrator = SafeAlloc::MakeUnique<PropertyRegistrator>("RouteEnvelopeRefType", EngineSideKind::ServerSide, _proto_hashes, *this);
-                ignore_unused(fields_registrator->RegisterProperty({"Common", "RouteSnapshot", "Primary"}));
-                ignore_unused(fields_registrator->RegisterProperty({"Common", "RouteSnapshot", "Backup"}));
-                ignore_unused(fields_registrator->RegisterProperty({"Common", "string", "Title"}));
+                (void)fields_registrator->RegisterProperty({"Common", "RouteSnapshot", "Primary"});
+                (void)fields_registrator->RegisterProperty({"Common", "RouteSnapshot", "Backup"});
+                (void)fields_registrator->RegisterProperty({"Common", "string", "Title"});
 
                 auto& ref_type = _ref_types["RouteEnvelope"];
                 ref_type.FieldsRegistrator = fields_registrator.get();

--- a/Source/Tests/Test_Timer.cpp
+++ b/Source/Tests/Test_Timer.cpp
@@ -91,10 +91,6 @@ TEST_CASE("GameTimer")
         timer.SetSynchronizedTimeMonotonic(older_time);
         CHECK(timer.GetSynchronizedTime() == current_time);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));
-        timer.FrameAdvance(false);
-        CHECK(timer.GetSynchronizedTime() == current_time);
-
         std::this_thread::sleep_for(std::chrono::milliseconds(120));
         timer.FrameAdvance(false);
         CHECK(timer.GetSynchronizedTime() > current_time);

--- a/Source/Tools/Mapper.cpp
+++ b/Source/Tools/Mapper.cpp
@@ -3448,7 +3448,7 @@ void MapperEngine::ApplyInspectorPropertyEdit(Entity* entity)
             const auto new_value = InspectorSelectedLineValue;
 
             if (!ApplyEntityPropertyText(entity, prop.get(), new_value)) {
-                ignore_unused(ApplyEntityPropertyText(entity, prop.get(), old_value));
+                ApplyEntityPropertyText(entity, prop.get(), old_value);
                 return;
             }
 
@@ -5795,7 +5795,7 @@ void MapperEngine::ParseCommand(string_view command)
             auto pmap = SafeAlloc::MakeRefCounted<ProtoMap>(Hashes.ToHashedString("new"), GetPropertyRegistrator(MapProperties::ENTITY_TYPE_NAME));
             pmap->SetSize({GameSettings::DEFAULT_MAP_SIZE, GameSettings::DEFAULT_MAP_SIZE});
 
-            auto map = SafeAlloc::MakeRefCounted<MapView>(this, ident_t {}, pmap.get());
+            auto map = SafeAlloc::MakeRefCounted<MapView>(this, ident_t {}, pmap.get(), App->MainWindow.GetSize());
             map->EnableMapperMode();
             map->SetScrollCheck(false);
             map->InstantScrollTo({GameSettings::DEFAULT_MAP_SIZE / 2, GameSettings::DEFAULT_MAP_SIZE / 2});
@@ -5908,7 +5908,7 @@ auto MapperEngine::LoadMapFromText(string_view map_name, const string& map_text)
     auto pmap = SafeAlloc::MakeRefCounted<ProtoMap>(Hashes.ToHashedString(map_name), GetPropertyRegistrator(MapProperties::ENTITY_TYPE_NAME));
     pmap->GetPropertiesForEdit().ApplyFromText(map_data.GetSection("ProtoMap"));
 
-    auto new_map = SafeAlloc::MakeRefCounted<MapView>(this, ident_t {}, pmap.get());
+    auto new_map = SafeAlloc::MakeRefCounted<MapView>(this, ident_t {}, pmap.get(), App->MainWindow.GetSize());
     new_map->EnableMapperMode();
     new_map->SetScrollCheck(false);
 

--- a/Source/Tools/Mapper.cpp
+++ b/Source/Tools/Mapper.cpp
@@ -6091,10 +6091,12 @@ void MapperEngine::UnloadMap(MapView* map, bool clear_undo)
     FO_RUNTIME_ASSERT(it != LoadedMaps.end());
 
     SetMapDirty(map, false);
+
     if (clear_undo) {
         ClearUndoContext(map);
     }
-    map->MarkAsDestroyed();
+
+    map->DestroySelf();
     LoadedMaps.erase(it);
 }
 

--- a/Source/Tools/ModelInfoBaker.cpp
+++ b/Source/Tools/ModelInfoBaker.cpp
@@ -170,6 +170,8 @@ struct BakedModelMeshInfo
 };
 
 static auto IsModelDescriptionTemplateFile(string_view path) -> bool;
+static auto GetModelDescriptionMaxWriteTime(const FileCollection& files, string_view fname) -> uint64_t;
+static void AccumulateModelDescriptionMaxWriteTime(const FileCollection& files, string_view fname, const vector<pair<string, string>>& replacements, vector<string>& include_stack, uint64_t& max_write_time);
 
 static void ValidateModelDescription(const FileCollection& source_files, const FileSystem& baked_files, const NameResolver& name_resolver, const BakerModelDescription& description, string_view fname);
 static void ValidateModelDescriptionAnimations(const NameResolver& name_resolver, const FileSystem& baked_files, unordered_map<string, BakedModelMeshInfo>& mesh_cache, const BakerModelDescription& description, string_view fname);
@@ -260,19 +262,26 @@ void ModelInfoBaker::BakeFiles(const FileCollection& files, string_view target_p
         return;
     }
 
-    vector<std::future<void>> file_bakings;
+    vector<File> files_to_bake;
 
     for (File& file_ : filtered_files) {
+        const uint64_t max_write_time = GetModelDescriptionMaxWriteTime(files, file_.GetPath());
+
+        if (_context->BakeChecker && !_context->BakeChecker(file_.GetPath(), max_write_time)) {
+            continue;
+        }
+
+        files_to_bake.emplace_back(std::move(file_));
+    }
+
+    vector<std::future<void>> file_bakings;
+
+    for (File& file_ : files_to_bake) {
         file_bakings.emplace_back(std::async(GetAsyncMode(), [this, &files, file = std::move(file_)]() FO_DEFERRED {
             const BakerClientEngine client_engine(*_context->BakedFiles);
             ModelDescriptionParser parser(files, client_engine);
-            auto [description, max_write_time] = parser.Parse(file.GetPath());
-
-            // Honour incremental baking: only skip after we know the newest write-time across the
-            // .fo3d itself and every Include'd template, so an unchanged description is not re-baked.
-            if (_context->BakeChecker && !_context->BakeChecker(file.GetPath(), max_write_time)) {
-                return;
-            }
+            auto [description, parsed_max_write_time] = parser.Parse(file.GetPath());
+            ignore_unused(parsed_max_write_time);
 
             ValidateModelDescription(files, *_context->BakedFiles, client_engine, description, file.GetPath());
 
@@ -305,6 +314,66 @@ static auto IsModelDescriptionTemplateFile(string_view path) -> bool
     FO_STACK_TRACE_ENTRY();
 
     return strex(path).extract_file_name().starts_with("TEMPLATE_");
+}
+
+static auto GetModelDescriptionMaxWriteTime(const FileCollection& files, string_view fname) -> uint64_t
+{
+    FO_STACK_TRACE_ENTRY();
+
+    vector<string> include_stack;
+    uint64_t max_write_time = 0;
+    AccumulateModelDescriptionMaxWriteTime(files, fname, {}, include_stack, max_write_time);
+    return max_write_time;
+}
+
+static void AccumulateModelDescriptionMaxWriteTime(const FileCollection& files, string_view fname, const vector<pair<string, string>>& replacements, vector<string>& include_stack, uint64_t& max_write_time)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    if (std::ranges::find(include_stack, fname) != include_stack.end()) {
+        throw ModelInfoBakerException(strex("Recursive model description include '{}'", fname));
+    }
+
+    File file = files.FindFileByPath(fname);
+
+    if (!file) {
+        throw ModelInfoBakerException(strex("Model description file '{}' not found", fname));
+    }
+
+    max_write_time = std::max(max_write_time, file.GetWriteTime());
+    include_stack.emplace_back(fname);
+
+    const string content = ApplyModelDescriptionReplacements(file.GetStr(), replacements);
+    auto istr = istringstream(content);
+    string line_buf;
+    size_t line = 0;
+
+    while (std::getline(istr, line_buf)) {
+        line++;
+
+        const vector<string> tokens = TokenizeModelDescriptionLine(line_buf);
+
+        if (tokens.empty() || tokens.front() != "Include") {
+            continue;
+        }
+        if (tokens.size() < 2) {
+            throw ModelInfoBakerException(strex("Missing include path in '{}' at line {}", fname, line));
+        }
+        if ((tokens.size() - 2) % 2 != 0) {
+            throw ModelInfoBakerException(strex("Include '{}' in '{}' at line {} has unpaired template argument", tokens[1], fname, line));
+        }
+
+        vector<pair<string, string>> include_replacements;
+
+        for (size_t i = 2; i < tokens.size(); i += 2) {
+            include_replacements.emplace_back(tokens[i], tokens[i + 1]);
+        }
+
+        const string include_path = strex(fname).extract_dir().combine_path(tokens[1]);
+        AccumulateModelDescriptionMaxWriteTime(files, include_path, include_replacements, include_stack, max_write_time);
+    }
+
+    include_stack.pop_back();
 }
 
 ModelDescriptionParser::ModelDescriptionParser(const FileCollection& files, const NameResolver& name_resolver) :
@@ -991,14 +1060,14 @@ static void ValidateModelDescriptionEnumValue(const NameResolver& name_resolver,
     FO_STACK_TRACE_ENTRY();
 
     bool metadata_missing = false;
-    ignore_unused(name_resolver.ResolveEnumValueName(enum_name, 0, &metadata_missing));
+    (void)name_resolver.ResolveEnumValueName(enum_name, 0, &metadata_missing);
 
     if (metadata_missing) {
         return;
     }
 
     bool failed = false;
-    ignore_unused(name_resolver.ResolveEnumValueName(enum_name, value, &failed));
+    (void)name_resolver.ResolveEnumValueName(enum_name, value, &failed);
 
     if (failed) {
         throw ModelInfoBakerException(strex("Invalid {} value '{}' for token '{}' in '{}'", enum_name, value, token, fname));
@@ -1159,7 +1228,7 @@ static void ReadBakedModelMeshAnimation(DataReader& reader, BakedModelMeshInfo& 
 {
     FO_STACK_TRACE_ENTRY();
 
-    ignore_unused(ReadBakedModelMeshString(reader)); // Animation file name
+    (void)ReadBakedModelMeshString(reader); // Animation file name
 
     const string anim_name = ReadBakedModelMeshString(reader);
 
@@ -1168,7 +1237,7 @@ static void ReadBakedModelMeshAnimation(DataReader& reader, BakedModelMeshInfo& 
     }
 
     info.AnimationNames.emplace_back(anim_name);
-    ignore_unused(reader.Read<float32_t>()); // Duration
+    (void)reader.Read<float32_t>(); // Duration
 
     const uint32_t hierarchy_count = reader.Read<uint32_t>();
 
@@ -1219,7 +1288,7 @@ static void SkipBakedModelMeshBytes(DataReader& reader, size_t size)
 {
     FO_STACK_TRACE_ENTRY();
 
-    ignore_unused(reader.ReadPtr<uint8_t>(size));
+    (void)reader.ReadPtr<uint8_t>(size);
 }
 
 static auto SkipBakedModelMeshFloatArray(DataReader& reader) -> uint32_t

--- a/Source/Tools/ModelInfoBaker.cpp
+++ b/Source/Tools/ModelInfoBaker.cpp
@@ -353,24 +353,30 @@ static void AccumulateModelDescriptionMaxWriteTime(const FileCollection& files, 
 
         const vector<string> tokens = TokenizeModelDescriptionLine(line_buf);
 
-        if (tokens.empty() || tokens.front() != "Include") {
-            continue;
-        }
-        if (tokens.size() < 2) {
-            throw ModelInfoBakerException(strex("Missing include path in '{}' at line {}", fname, line));
-        }
-        if ((tokens.size() - 2) % 2 != 0) {
-            throw ModelInfoBakerException(strex("Include '{}' in '{}' at line {} has unpaired template argument", tokens[1], fname, line));
-        }
+        for (size_t i = 0; i < tokens.size(); i++) {
+            if (tokens[i] != "Include") {
+                continue;
+            }
+            if (i + 1 >= tokens.size()) {
+                throw ModelInfoBakerException(strex("Missing include path in '{}' at line {}", fname, line));
+            }
 
-        vector<pair<string, string>> include_replacements;
+            const string& include_name = tokens[i + 1];
 
-        for (size_t i = 2; i < tokens.size(); i += 2) {
-            include_replacements.emplace_back(tokens[i], tokens[i + 1]);
+            if ((tokens.size() - (i + 2)) % 2 != 0) {
+                throw ModelInfoBakerException(strex("Include '{}' in '{}' at line {} has unpaired template argument", include_name, fname, line));
+            }
+
+            vector<pair<string, string>> include_replacements;
+
+            for (size_t j = i + 2; j < tokens.size(); j += 2) {
+                include_replacements.emplace_back(tokens[j], tokens[j + 1]);
+            }
+
+            const string include_path = strex(fname).extract_dir().combine_path(include_name);
+            AccumulateModelDescriptionMaxWriteTime(files, include_path, include_replacements, include_stack, max_write_time);
+            break;
         }
-
-        const string include_path = strex(fname).extract_dir().combine_path(tokens[1]);
-        AccumulateModelDescriptionMaxWriteTime(files, include_path, include_replacements, include_stack, max_write_time);
     }
 
     include_stack.pop_back();


### PR DESCRIPTION
Refactor Critter, Item, Location, and Map classes; implement spectator functionality

- Removed ViewMapContext from Critter class and adjusted related methods.
- Added destructor to Item and Location classes to ensure proper cleanup.
- Enhanced Map class to manage spectator players, including methods to add and remove spectators.
- Updated SendAndBroadcast methods in Critter to notify both critters and spectators.
- Modified Player class to manage view maps for spectators, including setting and resetting view maps.
- Refactored MapManager to handle spectator notifications during critter and item additions/removals.
- Improved server shutdown process to ensure all entities are properly cleaned up.
- Updated tests to reflect changes in property registration and model description handling.