### PR TITLE
Make packaged web server threaded with connection timeouts

### DIFF
--- a/BuildTools/web/simple-web-server.py
+++ b/BuildTools/web/simple-web-server.py
@@ -10,11 +10,14 @@ import socketserver
 import sys
 
 
-class ReusableTCPServer(socketserver.TCPServer):
+class ReusableThreadingTCPServer(socketserver.ThreadingTCPServer):
     allow_reuse_address = True
+    daemon_threads = True
 
 
 class NoCacheHttpRequestHandler(http.server.SimpleHTTPRequestHandler):
+    timeout = 30
+
     def end_headers(self) -> None:
         self.send_header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
         self.send_header('Pragma', 'no-cache')
@@ -42,7 +45,7 @@ def main() -> None:
 
     serve_dir = os.path.dirname(os.path.realpath(__file__))
     handler = functools.partial(NoCacheHttpRequestHandler, directory=serve_dir)
-    with ReusableTCPServer(('', args.port), handler) as httpd:
+    with ReusableThreadingTCPServer(('', args.port), handler) as httpd:
         print('Serving', serve_dir, 'at port', args.port)
         httpd.serve_forever()
 


### PR DESCRIPTION
The `web-server.py` helper emitted by `BuildTools/package.py` (from `BuildTools/web/simple-web-server.py`) served requests on a single-threaded `socketserver.TCPServer` with no socket timeout. One client that connects and then stalls (sends nothing, or reads slowly) parks the only handler loop; once the accept backlog fills, the web client becomes unreachable while the process still looks alive — observed in production hosting the browser build.

Fix, kept game-agnostic and minimal:
- `socketserver.ThreadingTCPServer` with `daemon_threads = True` (keeps `allow_reuse_address`), so each connection is handled on its own thread;
- `timeout = 30` on the request handler, so a half-dead connection raises `TimeoutError` in `BaseHTTPRequestHandler` and releases its thread.

No-cache headers, directory-serving behavior, and the `--port`/`--fork` CLI are unchanged.

Validated standalone (scratch dir, high port): plain GET serves with the no-cache headers; with a stalled raw-socket client connected, 5 concurrent GETs all complete in <10 ms; the stalled socket is closed by the server (EOF) after 30.0 s and the server stays healthy afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)