### PR TITLE
Fix race that dropped suspended script context resume on multithreaded scheduler

### DIFF
--- a/Source/Scripting/AngelScript/AngelScriptContext.cpp
+++ b/Source/Scripting/AngelScript/AngelScriptContext.cpp
@@ -452,22 +452,12 @@ void AngelScriptContextManager::ResumeSpecificContext(AngelScript::asIScriptCont
         auto* ctx_ext = AngelScriptContextExtendedData::Get(ctx);
         FO_RUNTIME_ASSERT(ctx_ext);
 
-        // SuspendScriptContext schedules this resume from inside the script call (Global_Yield),
-        // before the VM unwinds out of Execute() and the context state actually becomes
-        // SUSPENDED. On a multithreaded scheduler the resume job can fire inside that window:
-        // the context is still flagged as executing while its state still reads ACTIVE. The
-        // executing flag therefore must be checked BEFORE the state check — otherwise this
-        // resume would be dropped below and the suspended coroutine lost forever (observed as
-        // permanently hung [[Async]] server flows). While the previous run is still unwinding,
-        // re-arm the resume and retry shortly.
         if (ctx_ext->ExecutionActive.load()) {
             FO_RUNTIME_ASSERT(_delayedScheduler);
             _delayedScheduler(std::chrono::milliseconds(1), [this, ctx]() { ResumeSpecificContext(ctx); });
             return;
         }
 
-        // Not executing and not suspended: the context already finished or was aborted and is
-        // about to leave the busy list — nothing to resume.
         if (ctx->GetState() != AngelScript::asEXECUTION_SUSPENDED) {
             return;
         }

--- a/Source/Scripting/AngelScript/AngelScriptContext.cpp
+++ b/Source/Scripting/AngelScript/AngelScriptContext.cpp
@@ -448,16 +448,27 @@ void AngelScriptContextManager::ResumeSpecificContext(AngelScript::asIScriptCont
         if (it == _busyContexts.end()) {
             return;
         }
-        if (ctx->GetState() != AngelScript::asEXECUTION_SUSPENDED) {
-            return;
-        }
 
         auto* ctx_ext = AngelScriptContextExtendedData::Get(ctx);
         FO_RUNTIME_ASSERT(ctx_ext);
 
+        // SuspendScriptContext schedules this resume from inside the script call (Global_Yield),
+        // before the VM unwinds out of Execute() and the context state actually becomes
+        // SUSPENDED. On a multithreaded scheduler the resume job can fire inside that window:
+        // the context is still flagged as executing while its state still reads ACTIVE. The
+        // executing flag therefore must be checked BEFORE the state check — otherwise this
+        // resume would be dropped below and the suspended coroutine lost forever (observed as
+        // permanently hung [[Async]] server flows). While the previous run is still unwinding,
+        // re-arm the resume and retry shortly.
         if (ctx_ext->ExecutionActive.load()) {
             FO_RUNTIME_ASSERT(_delayedScheduler);
             _delayedScheduler(std::chrono::milliseconds(1), [this, ctx]() { ResumeSpecificContext(ctx); });
+            return;
+        }
+
+        // Not executing and not suspended: the context already finished or was aborted and is
+        // about to leave the busy list — nothing to resume.
+        if (ctx->GetState() != AngelScript::asEXECUTION_SUSPENDED) {
             return;
         }
     }


### PR DESCRIPTION
Резюм Yield-корутины планируется изнутри скриптового вызова (`Global_Yield` → `SuspendScriptContext` → `ScheduleDelayedCallback`), до того как VM размотается из `Execute()` и состояние контекста станет `SUSPENDED` (`asCContext::Suspend()` лишь выставляет флаги). На серверном `WorkerPool` другой воркер успевает взять due-now резюм-джобу в этом окне: `ResumeSpecificContext` видел `state == ACTIVE` и молча отбрасывал резюм — корутина навсегда оставалась в `_busyContexts`. Наблюдалось как вечное зависание серверных `[[Async]]`-флоу: в LF — веб-логин (Yield(0)-цикл опроса веб-запроса) висел без единой строки в логе (tracker 1795569028316530104, Staging 0.3.330).

Фикс: проверка `ExecutionActive` перенесена перед проверкой состояния — пока предыдущий прогон разматывается, резюм перевзводится (тот же механизм, что и для окна `SUSPENDED`+`ExecutionActive`). Drop остаётся только для завершённых/прерванных контекстов.

Клиентский шедулер не подвержен (`ClientEngine::ScheduleDelayedCallback` обрабатывается однопоточно в main loop). До мультитредового пула (#166) резюмы поллились каждый кадр — потеря была невозможна.

Валидация (LF, cvet-server-3): новый гейм-тест `web_login_yield_resume_survives_rapid_yield_spin` (3000×Yield(0)) — timeout на коде без фикса, <1с с фиксом; реальный веб-логин в SceneLaunch — hang 2/2 → `player_logged_in` 2/2; `LF_UnitTests` — 273 кейса зелёные; полный гейм-сьют — без новых падений и таймаутов.

Совместимость: только внутрипроцессный шедулинг, сетевой протокол и сериализованные контракты не затронуты — маркер `///@ MigrationRule Version` не бампается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)