### PR TITLE
Sync-rail: ordered-fair escalation breaks nested cross-entity deadlock (latent #211)

### DIFF
--- a/Source/Server/EntitySync.cpp
+++ b/Source/Server/EntitySync.cpp
@@ -1102,11 +1102,37 @@ void SyncContext::AcquireLocksOrderedFair(const vector<EntityLock*>& locks)
     vector<pair<EntityLock*, int32_t>> ordered {reacquire_count.begin(), reacquire_count.end()};
     std::ranges::sort(ordered, {}, &pair<EntityLock*, int32_t>::first);
 
+    // `Acquire` blocks and throws `EntityLockWaitAbortedException` if the server shuts down while it
+    // is parked. Reaching that here would corrupt the lock bookkeeping unless we recover: we have
+    // already released the whole union to zero and would only partially restore it, so the ancestor
+    // SyncContexts still list locks this thread no longer owns — their teardown `Release()` would
+    // strong-assert on an unowned lock. Re-acquiring is impossible (the abort keeps firing throughout
+    // shutdown), so on failure bring the entire union back to zero and drop it from every ancestor's
+    // bookkeeping, leaving a consistent "this thread holds nothing" state that unwinds cleanly. The
+    // guard is released after a normal acquire, so it fires only on the abort (or any other) throw.
+    auto restore_on_abort = scope_fail([this, &reacquire_count]() noexcept {
+        for (auto& [lock, count] : reacquire_count) {
+            const int32_t held = lock->GetExclusiveRecursionForCurrentThread();
+
+            for (int32_t i = 0; i < held; i++) {
+                lock->Release();
+            }
+        }
+
+        for (auto* ancestor = _previousContext; ancestor != nullptr; ancestor = ancestor->_previousContext) {
+            ancestor->_heldLocks.clear();
+            ancestor->_heldLockOwners.clear();
+            ancestor->_singletonLocks.clear();
+        }
+    });
+
     for (auto& [lock, count] : ordered) {
         for (int32_t i = 0; i < count; i++) {
             lock->Acquire(NextSyncTicket());
         }
     }
+
+    restore_on_abort.release();
 }
 
 void SyncContext::ReleaseLocks() noexcept

--- a/Source/Server/EntitySync.cpp
+++ b/Source/Server/EntitySync.cpp
@@ -342,6 +342,21 @@ auto EntityLock::WaiterCount() const noexcept -> size_t
     return _waitQueue.size();
 }
 
+auto EntityLock::GetExclusiveRecursionForCurrentThread() const noexcept -> int32_t
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    if (_ownerThread.load(std::memory_order_acquire) != std::this_thread::get_id()) {
+        return 0;
+    }
+
+    scoped_lock locker {_mutex};
+
+    // Re-check under the lock: a concurrent Release on this thread cannot happen (we are the owner
+    // and single-threaded for our own lock state), so the owner check + recursion read are stable.
+    return _ownerThread.load(std::memory_order_relaxed) == std::this_thread::get_id() ? _recursionCount : 0;
+}
+
 auto IsEntityAccessValid(const ServerEntity* entity) noexcept -> bool
 {
     FO_NO_STACK_TRACE_ENTRY();
@@ -981,27 +996,35 @@ void SyncContext::AcquireLocks(vector<EntityLock*>& locks, vector<refcount_ptr<S
         }
     }
 
-    // Acquire the whole (now sorted, deduped) set WITHOUT ever parking while holding another lock —
-    // a std::lock-style try-and-back-off. A SyncContext can be NESTED: a per-event-callback context
-    // runs while its parent job/event context already holds locks at arbitrary addresses (e.g.
-    // `Process_RemoteCall` holds the player lock, then `OnPlayerLogin` fires and a handler calls
-    // `Game.Sync(...)` on the nested context). Block-waiting on a lock here while the thread still
-    // holds a parent lock at a HIGHER address inverts the global ascending-address order and
-    // deadlocks against a concurrent acquisition that wants the same pair in the opposite arrival
-    // order (observed: a fresh login holding the player lock vs. that player's controlled-critter
-    // TimeEvent, which auto-widens back to the player).
+    // Acquisition strategy (two stages):
     //
-    // Sorted ascending-address acquisition alone is NOT sufficient: the parent locks were taken
-    // outside this call and cannot be safely released here (that would drop the parent's atomicity
-    // and corrupt its held-lock bookkeeping). Instead, we never hold-and-wait — try-acquire the whole
-    // set; on the first contended lock, release the prefix we just took and retry after a back-off.
-    // Releasing a re-entrant parent lock in the prefix only moves its recursion count, so the parent
-    // keeps its hold. Because the thread never blocks while holding a lock, no wait-for cycle can
-    // form. Locks already owned by this thread (the parent cover) succeed immediately via
-    // TryAcquire's re-entrant fast path and never trigger back-off.
-    const bool can_wait_for_fair_turn = _previousContext == nullptr;
+    // Stage 1 — non-parking try-and-back-off (the fast path for transient contention). Try-acquire
+    // the whole (sorted, deduped) set; on the first contended lock, release the prefix we just took
+    // and spin-yield. This never holds-and-waits *for the duration of one attempt*, so a briefly
+    // contended lock is taken promptly without parking. Locks already owned by this thread (the
+    // parent cover) succeed immediately via TryAcquire's re-entrant fast path.
+    //
+    // Stage 2 — globally-ordered fair acquire (the deadlock-breaker). Stage 1 alone is NOT
+    // sufficient for NESTED contexts: a per-event-callback context runs while its parent job/event
+    // context already holds locks at arbitrary addresses (e.g. a per-player job covers {player,
+    // controlled critter}; `OnPlayerLogout` fires and a handler calls `Sync(cr, leader)` on the
+    // nested context). Those parent locks are held for the WHOLE nested attempt — that is real
+    // hold-and-wait. Two concurrent group-logout cleanups form a genuine 2-cycle: thread 1's parent
+    // holds cr_a and the nested acquire wants {cr_a, cr_b}; thread 2's parent holds cr_b and wants
+    // {cr_b, cr_a}. The contended lock is permanently held by the OTHER thread's parent, so no
+    // amount of non-parking back-off in stage 1 can ever break it (each thread spins forever holding
+    // the lock the other needs). The escalation therefore releases the ENTIRE thread-held lock set
+    // (this context's prefix + every ancestor SyncContext's locks, since `Sync()` observes no entity
+    // state during a lock-set transition) and re-acquires the full union with BLOCKING `Acquire` in
+    // strict ascending-address order. Total resource ordering makes that fair acquire deadlock-free
+    // for any context, nested or not: no thread can hold a higher-addressed lock while blocking on a
+    // lower-addressed one, so no wait-for cycle can form. Each ancestor lock's recursion count is
+    // restored exactly, so parent bookkeeping is intact when control returns to the parent.
+    constexpr int32_t non_parking_spin_budget = 64;
 
-    for (int32_t spins = 0;;) {
+    bool acquired_all = false;
+
+    for (int32_t spins = 0; spins < non_parking_spin_budget; spins++) {
         size_t acquired = 0;
 
         while (acquired < locks.size() && locks[acquired]->TryAcquire()) {
@@ -1009,6 +1032,7 @@ void SyncContext::AcquireLocks(vector<EntityLock*>& locks, vector<refcount_ptr<S
         }
 
         if (acquired == locks.size()) {
+            acquired_all = true;
             break;
         }
 
@@ -1016,23 +1040,73 @@ void SyncContext::AcquireLocks(vector<EntityLock*>& locks, vector<refcount_ptr<S
             locks[i]->Release();
         }
 
-        // Escalating back-off: spin-yield first so a briefly-contended lock is taken promptly. A
-        // top-level context can then queue briefly for the contended lock and release it immediately,
-        // which gives the lock a visible exclusive waiter and prevents an endless stream of shared
-        // readers from starving this sync attempt. Nested contexts must keep the non-parking rule
-        // because their parent may already hold unrelated locks.
-        if (++spins < 64 || !can_wait_for_fair_turn) {
-            std::this_thread::yield();
-        }
-        else {
-            locks[acquired]->Acquire(NextSyncTicket());
-            locks[acquired]->Release();
-            std::this_thread::sleep_for(std::chrono::microseconds(50));
-        }
+        std::this_thread::yield();
+    }
+
+    if (!acquired_all) {
+        AcquireLocksOrderedFair(locks);
     }
 
     _heldLocks = std::move(locks);
     _heldLockOwners = std::move(owners);
+}
+
+void SyncContext::AcquireLocksOrderedFair(const vector<EntityLock*>& locks)
+{
+    FO_STACK_TRACE_ENTRY();
+
+    // Collect every lock the calling thread currently holds across the ancestor SyncContext chain
+    // (each context's per-Sync `_heldLocks` plus its singleton `_singletonLocks`) together with this
+    // call's target `locks`, recording each lock's current exclusive recursion so it can be released
+    // to zero and re-acquired the same number of times. `this` context's own prefix is already
+    // released by the stage-1 back-off, so it contributes only via `locks` (recursion 0 here).
+    unordered_map<EntityLock*, int32_t> reacquire_count;
+
+    const auto add_held = [&reacquire_count](EntityLock* lock) {
+        if (lock != nullptr && !reacquire_count.contains(lock)) {
+            reacquire_count.emplace(lock, lock->GetExclusiveRecursionForCurrentThread());
+        }
+    };
+
+    for (auto* ancestor = _previousContext; ancestor != nullptr; ancestor = ancestor->_previousContext) {
+        for (auto* lock : ancestor->_heldLocks) {
+            add_held(lock);
+        }
+        for (auto* lock : ancestor->_singletonLocks) {
+            add_held(lock);
+        }
+    }
+
+    // The target locks of THIS acquire each need exactly one extra hold on top of whatever ancestors
+    // already hold them.
+    for (auto* lock : locks) {
+        reacquire_count[lock] += 1;
+    }
+
+    // Release every currently-held lock down to zero so the whole union becomes orderable. After this
+    // the calling thread holds none of these locks; another thread that was waiting on one can take
+    // it, which is exactly what breaks a cross-hold 2-cycle. No entity state is observed between here
+    // and the ordered re-acquire below, so dropping the parent cover across the transition is safe —
+    // the parent cover is fully restored (as a superset) before control returns to any script.
+    for (auto& [lock, count] : reacquire_count) {
+        const int32_t held = lock->GetExclusiveRecursionForCurrentThread();
+
+        for (int32_t i = 0; i < held; i++) {
+            lock->Release();
+        }
+    }
+
+    // Re-acquire the entire union in strict ascending-address order with the FIFO-fair blocking
+    // `Acquire`. Ascending order across all threads prevents any wait-for cycle (resource ordering);
+    // the FIFO ticket queue prevents starvation.
+    vector<pair<EntityLock*, int32_t>> ordered {reacquire_count.begin(), reacquire_count.end()};
+    std::ranges::sort(ordered, {}, &pair<EntityLock*, int32_t>::first);
+
+    for (auto& [lock, count] : ordered) {
+        for (int32_t i = 0; i < count; i++) {
+            lock->Acquire(NextSyncTicket());
+        }
+    }
 }
 
 void SyncContext::ReleaseLocks() noexcept

--- a/Source/Server/EntitySync.h
+++ b/Source/Server/EntitySync.h
@@ -59,6 +59,12 @@ public:
     [[nodiscard]] auto IsLockedByCurrentThread() const noexcept -> bool;
     [[nodiscard]] auto WaiterCount() const noexcept -> size_t;
 
+    // Number of times the calling thread currently holds this lock EXCLUSIVELY (its recursion
+    // count), or 0 if it is not the exclusive owner. Used by the globally-ordered escalation in
+    // `SyncContext::AcquireLocks` to release a parent-held lock down to zero and re-acquire it the
+    // same number of times, restoring the parent context's recursion bookkeeping exactly.
+    [[nodiscard]] auto GetExclusiveRecursionForCurrentThread() const noexcept -> int32_t;
+
     // Exclusive ("write") acquisition. One owner thread at a time; re-entrant on that thread via
     // `_recursionCount`. Blocks until no shared holders and no other exclusive owner remain.
     void Acquire(uint64_t ticket);
@@ -147,6 +153,14 @@ public:
 
 private:
     void AcquireLocks(vector<EntityLock*>& locks, vector<refcount_ptr<ServerEntity>>&& owners);
+    // Deadlock-breaking escalation used by AcquireLocks when the non-parking back-off cannot make
+    // progress (typically a nested context cross-holding locks against another thread's parent
+    // cover). Releases the full thread-held lock union (this context's prefix is already released by
+    // the caller, plus every ancestor SyncContext's per-Sync and singleton locks) and re-acquires it
+    // in strict ascending-address order via the FIFO-fair blocking `EntityLock::Acquire`, restoring
+    // each ancestor lock's recursion count exactly. Total resource ordering makes this fair acquire
+    // deadlock-free regardless of what the thread (or its ancestors) already held.
+    void AcquireLocksOrderedFair(const vector<EntityLock*>& locks);
     void ReleaseLocks() noexcept;
     void ReleaseSingletonLocks() noexcept;
 

--- a/Source/Server/EntitySync.h
+++ b/Source/Server/EntitySync.h
@@ -159,7 +159,9 @@ private:
     // the caller, plus every ancestor SyncContext's per-Sync and singleton locks) and re-acquires it
     // in strict ascending-address order via the FIFO-fair blocking `EntityLock::Acquire`, restoring
     // each ancestor lock's recursion count exactly. Total resource ordering makes this fair acquire
-    // deadlock-free regardless of what the thread (or its ancestors) already held.
+    // deadlock-free regardless of what the thread (or its ancestors) already held. If the blocking
+    // re-acquire is aborted by shutdown, it rolls the whole union back to zero and clears the ancestor
+    // bookkeeping so the unwinding contexts don't release locks they no longer hold.
     void AcquireLocksOrderedFair(const vector<EntityLock*>& locks);
     void ReleaseLocks() noexcept;
     void ReleaseSingletonLocks() noexcept;

--- a/Source/Tests/Test_ServerEngine.cpp
+++ b/Source/Tests/Test_ServerEngine.cpp
@@ -1497,4 +1497,190 @@ TEST_CASE("ServerEngineSyncContextFlatAcquisition")
     cr_b->SetParent(nullptr);
 }
 
+// ============================================================================
+// Nested cross-entity acquisition must not deadlock. Two worker threads each run a PRIMARY
+// SyncContext that already covers one critter (mirrors a per-player job whose cover is {player,
+// controlled critter} via auto-widen), then each fires a callback whose NESTED SyncContext requests
+// BOTH critters in the OPPOSITE order — exactly what two concurrent group-logout cleanups do
+// (`Groups::OnPlayerLogout` → `KickCritterFromGroup` → `Sync::Lock(cr, leader)`). Thread 1 holds
+// cr_a (parent) and wants {cr_a, cr_b}; thread 2 holds cr_b (parent) and wants {cr_b, cr_a}: a
+// genuine hold-and-wait 2-cycle. A nested acquire that only spins non-parking (holding the parent's
+// lock the whole time) can never break this — the contended lock is permanently held by the other
+// thread's parent. The acquire must escalate to a globally-ordered blocking acquire of the full
+// thread-held union (releasing parent locks across the transition, since no entity state is observed
+// during a lock-set change) so both threads converge. Guarded by a watchdog so a regression reports
+// a clean failure instead of hanging the whole unit-test process.
+// ============================================================================
+
+TEST_CASE("ServerEngineSyncContextNestedCrossEntityNoDeadlock")
+{
+    auto settings = MakeServerTestSettings();
+    auto server = SafeAlloc::MakeRefCounted<ServerEngine>(settings, MakeServerTestResources());
+
+    auto shutdown = scope_exit([&server]() noexcept {
+        safe_call([&server] {
+            if (server->IsStarted()) {
+                server->Shutdown();
+            }
+        });
+    });
+
+    const auto startup_error = WaitForServerStart(server.get());
+    INFO(startup_error);
+    REQUIRE(startup_error.empty());
+
+    const auto critter_pid = server->Hashes.ToHashedString("UnitTestRat");
+    const auto location_pid = server->Hashes.ToHashedString("UnitTestLocation");
+    const auto map_pid = server->Hashes.ToHashedString("UnitTestMap");
+
+    REQUIRE(server->Lock(timespan {std::chrono::seconds {10}}));
+    bool locked = true;
+    auto unlock = scope_exit([&server, &locked]() noexcept {
+        safe_call([&server, &locked] {
+            if (locked) {
+                server->Unlock();
+            }
+        });
+    });
+
+    // Two critters on DIFFERENT maps so each keeps its OWN lock (no sibling escalation to a shared
+    // map lock would collapse the pair and hide the cross-lock contention).
+    auto* loc = server->MapMngr.CreateLocation(location_pid, vector<hstring> {map_pid, map_pid});
+    REQUIRE(loc != nullptr);
+    auto* map_a = loc->GetMapByIndex(0);
+    auto* map_b = loc->GetMapByIndex(1);
+    REQUIRE(map_a != nullptr);
+    REQUIRE(map_b != nullptr);
+
+    auto* cr_a = server->CreateCritter(critter_pid, false);
+    auto* cr_b = server->CreateCritter(critter_pid, false);
+    REQUIRE(cr_a != nullptr);
+    REQUIRE(cr_b != nullptr);
+    server->MapMngr.TransferToMap(cr_a, map_a, mpos {10, 10}, mdir {}, std::nullopt);
+    server->MapMngr.TransferToMap(cr_b, map_b, mpos {12, 12}, mdir {}, std::nullopt);
+
+    server->Unlock();
+    locked = false;
+
+    constexpr int32_t ROUNDS = 400;
+
+    std::atomic<int64_t> rounds_done {0};
+    std::atomic_bool failed {false};
+
+    // Per-round rendezvous taken BEFORE any lock is acquired, so neither thread ever waits at the
+    // barrier while holding a lock (that would be a harness-level deadlock independent of the rail).
+    // Once both threads pass the barrier they acquire {primary cover} then {nested cross cover}
+    // back-to-back, so the two opposite-order cross-acquires overlap and the 2-cycle is hammered
+    // every round. No lock is held across any wait point in the harness itself.
+    std::atomic<int32_t> arrive {0};
+    std::atomic<int32_t> generation {0};
+    std::atomic<int32_t> primary_held {0};
+
+    const auto barrier = [&](int32_t round) {
+        const int32_t gen = generation.load(std::memory_order_acquire);
+        if (arrive.fetch_add(1, std::memory_order_acq_rel) + 1 == 2) {
+            arrive.store(0, std::memory_order_release);
+            generation.store(round + 1, std::memory_order_release);
+        }
+        else {
+            while (generation.load(std::memory_order_acquire) == gen && !failed.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+        }
+    };
+
+    const auto cross_thread = [&](ServerEntity* own, ServerEntity* peer) {
+        for (int32_t round = 0; round < ROUNDS && !failed.load(std::memory_order_acquire); round++) {
+            // Outer rendezvous while holding NO lock, so both threads start the locked section
+            // together (and the per-round primary_held counter starts clean).
+            primary_held.store(0, std::memory_order_relaxed);
+            barrier(round);
+
+            SyncContext primary;
+            primary.Activate();
+
+            // Primary cover: this thread's "own" critter (like a player job's controlled critter,
+            // already covered when an event fires).
+            vector<ServerEntity*> primary_req {own};
+            try {
+                primary.SyncEntities(primary_req);
+
+                // Inner rendezvous holding ONLY the primary: spin (bounded, no lock-ordering hazard —
+                // just an atomic) until the peer also holds its primary. This makes the nested
+                // cross-acquire below near-deterministically collide: both threads request {own, peer}
+                // in OPPOSITE order while each holds (via its primary) the lock the other needs — a
+                // genuine cross hold-and-wait 2-cycle. The fixed engine breaks it via the ordered-fair
+                // escalation; an unfixed engine spins forever (regression caught by the watchdog).
+                primary_held.fetch_add(1, std::memory_order_acq_rel);
+                for (int32_t spin = 0; spin < 100000 && primary_held.load(std::memory_order_acquire) < 2 && !failed.load(std::memory_order_acquire); spin++) {
+                    std::this_thread::yield();
+                }
+
+                // Nested context (like a per-callback FireEvent scope) requesting BOTH critters.
+                SyncContext nested;
+                nested.Activate();
+                auto nested_cleanup = scope_exit([&]() noexcept {
+                    nested.Release();
+                    nested.Deactivate();
+                });
+
+                vector<ServerEntity*> nested_req {own, peer};
+                nested.SyncEntities(nested_req);
+                CHECK(IsEntityAccessValid(own));
+                CHECK(IsEntityAccessValid(peer));
+            }
+            catch (const std::exception&) {
+                failed.store(true, std::memory_order_release);
+            }
+
+            primary.Release();
+            primary.Deactivate();
+            rounds_done.fetch_add(1, std::memory_order_relaxed);
+        }
+    };
+
+    std::thread t1(cross_thread, cr_a, cr_b);
+    std::thread t2(cross_thread, cr_b, cr_a);
+
+    // Watchdog: a correct implementation finishes the cross-rounds in well under a second even on a
+    // loaded host. If the threads deadlock, detect it and fail cleanly. We can't safely unblock a real
+    // deadlock, so on timeout we Shutdown (aborts pending entity-lock waiters) and detach — but the
+    // fixed engine never reaches the timeout. Both threads run ROUNDS rounds, so the target is 2*ROUNDS.
+    constexpr int64_t total_rounds = int64_t {ROUNDS} * 2;
+    const auto deadline = nanotime::now() + timespan {std::chrono::seconds {30}};
+    bool timed_out = false;
+    while (rounds_done.load(std::memory_order_acquire) < total_rounds && !failed.load(std::memory_order_acquire)) {
+        if (nanotime::now() > deadline) {
+            timed_out = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    CHECK_FALSE(timed_out); // a hang here is the sync-rail nested cross-entity deadlock (regression)
+    CHECK_FALSE(failed.load());
+
+    if (timed_out) {
+        // Best-effort: wake any thread stuck in a shutdown-abortable wait so the process can exit
+        // rather than hang the whole suite. The CHECK above already recorded the failure.
+        failed.store(true, std::memory_order_release);
+        server->Shutdown();
+        t1.detach();
+        t2.detach();
+    }
+    else {
+        t1.join();
+        t2.join();
+        CHECK(rounds_done.load() == total_rounds);
+    }
+
+    if (!timed_out) {
+        // Detach so the map refcounts drop cleanly before Shutdown.
+        REQUIRE(server->Lock(timespan {std::chrono::seconds {10}}));
+        locked = true;
+        cr_a->SetParent(nullptr);
+        cr_b->SetParent(nullptr);
+    }
+}
+
 FO_END_NAMESPACE

--- a/Source/Tests/Test_ServerEngine.cpp
+++ b/Source/Tests/Test_ServerEngine.cpp
@@ -1616,18 +1616,28 @@ TEST_CASE("ServerEngineSyncContextNestedCrossEntityNoDeadlock")
                     std::this_thread::yield();
                 }
 
-                // Nested context (like a per-callback FireEvent scope) requesting BOTH critters.
-                SyncContext nested;
-                nested.Activate();
-                auto nested_cleanup = scope_exit([&]() noexcept {
-                    nested.Release();
-                    nested.Deactivate();
-                });
+                // The rendezvous MUST be met before the nested cross-acquire: if the peer never
+                // reached its primary, the two opposite-order acquires don't overlap, the 2-cycle
+                // never forms, and even a broken engine would slip through as a false PASS. The budget
+                // is very generous (the peer only has to take one uncontended primary lock), so a miss
+                // means the setup is broken — fail hard instead of running a non-diagnostic acquire.
+                if (primary_held.load(std::memory_order_acquire) < 2) {
+                    failed.store(true, std::memory_order_release);
+                }
+                else {
+                    // Nested context (like a per-callback FireEvent scope) requesting BOTH critters.
+                    SyncContext nested;
+                    nested.Activate();
+                    auto nested_cleanup = scope_exit([&]() noexcept {
+                        nested.Release();
+                        nested.Deactivate();
+                    });
 
-                vector<ServerEntity*> nested_req {own, peer};
-                nested.SyncEntities(nested_req);
-                CHECK(IsEntityAccessValid(own));
-                CHECK(IsEntityAccessValid(peer));
+                    vector<ServerEntity*> nested_req {own, peer};
+                    nested.SyncEntities(nested_req);
+                    CHECK(IsEntityAccessValid(own));
+                    CHECK(IsEntityAccessValid(peer));
+                }
             }
             catch (const std::exception&) {
                 failed.store(true, std::memory_order_release);


### PR DESCRIPTION
Латентный дефект sync-рейла #211, вскрытый фиксом резюма Yield-корутин (#169): два одновременных group-logout cleanup'а виснут навечно.

## Дефект

Каждый PlayerJob держит первичный `SyncContext` с покрытием `{player, controlled critter}` (авто-widen Player↔криттер). На дисконнекте срабатывает `OnPlayerLogout`, хендлер вызывает `Sync(cr, leader)` во **вложенном** `SyncContext`. Поток A держит (через родителя) `cr_a` и хочет `{cr_a, cr_b}`; поток B держит `cr_b` и хочет `{cr_b, cr_a}` — настоящий hold-and-wait 2-цикл.

Старый `AcquireLocks` отключал честную эскалацию для вложенных контекстов (`can_wait_for_fair_turn == _previousContext == nullptr`) и только крутил non-parking. Но контендед-лок навсегда держит **родительское** покрытие другого потока, поэтому non-parking back-off не может разорвать цикл: оба потока крутятся вечно. Воспроизведено **3/3** на полном прогоне GameplayTests (все треды в `futex_wait`, 0% CPU). Стеки: WorkerPool-воркер крутится в `SyncContext::AcquireLocks` (`Game.Sync(e1,e2)`, спин на 1025) ↔ второй такой же ↔ тред ParallelTesting-раннера паркуется в `EntityLock::Acquire` (1028, `Game.Sync(e1)`) на той же сущности; SyncPoint-джоб запаркован (`Server.cpp:1191`). Прежний полный дамп — `Workspace/livelock_stacks_20260612.txt`. Тезис дока «no wait-for cycle can form» верен только против транзиентно-удерживаемых локов, не против чужого родительского покрытия.

## Фикс

Когда non-parking back-off (ограничен 64 спинами) не берёт сет, эскалируем через `AcquireLocksOrderedFair` для **любого** контекста. Он освобождает **весь** удерживаемый тредом union локов (префикс этого контекста + per-Sync и singleton-локи каждого родительского `SyncContext` — безопасно, т.к. `Sync()` не наблюдает состояние сущностей на переходе lock-set) и заново берёт весь union честным блокирующим `Acquire` в строгом порядке возрастания адресов. Полное упорядочивание ресурсов делает честное взятие deadlock-free независимо от того, что держит тред и его предки: ни один тред не держит лок с большим адресом, паркуясь на лок с меньшим → цикла ожидания не образуется. Рекурсия каждого родительского лока освобождается до нуля и восстанавливается ровно — bookkeeping родителя цел.

Семантика per-engine sync, гранулярность локов, сетевой протокол и сериализованные контракты не тронуты — это внутренний шедулинг, **bump compat-версии не нужен**.

## Регрессия

`Test_ServerEngine` → `ServerEngineSyncContextNestedCrossEntityNoDeadlock` воспроизводит ровно 2-цикл (два потока, встречный порядок вложенного cross-acquire, каждый держит peer-лок через свой primary). Доказано fail-before/pass-after: на нефикшенном движке — RED (watchdog timeout / deadlock), с фиксом — 6/6 зелёных и быстро. `RunUnitTests` чистый (единственный фейл полного прогона — pre-existing тайминг-флейк `WorkThread.PauseBlocksJobsUntilResume` под нагрузкой CI, не связан).

Не мержить в `master` — на ревью владельцу.
