### PR TITLE
Add additive Game.SyncEnsure script export

### DIFF
--- a/Source/Scripting/ServerGlobalScriptMethods.cpp
+++ b/Source/Scripting/ServerGlobalScriptMethods.cpp
@@ -1509,6 +1509,24 @@ FO_SCRIPT_API void Server_Game_Sync(ServerEngine* server, readonly_vector<Server
 }
 
 ///@ ExportMethod
+FO_SCRIPT_API void Server_Game_SyncEnsure(ServerEngine* server, ServerEntity* entity)
+{
+    auto* ctx = server->GetCurrentSyncContext();
+    FO_VERIFY_AND_THROW(ctx, "Missing script execution context");
+
+    // Additive cover widen. Unlike Sync (which releases-and-reacquires the whole held set on a
+    // yield-on-sync boundary and is therefore Async), EnsureEntitySynced only *widens* the held set
+    // through the non-parking TryAcquire / AcquireLocks path: it never enqueues and never suspends
+    // the coroutine, so this export is not Async and is callable from synchronous code. In the fully
+    // unrestricted/auto-lock context it is a no-op (a synchronous caller relying on per-property
+    // auto-locking keeps that behaviour); in a restricted context (held entity locks and/or
+    // Game.Lock()) it adds the entity to the held set without dropping the caller's existing cover.
+    // This lets a cross-entity reader (e.g. the analytics emit) stay correct when invoked from a
+    // coroutine that resumed in a partial cover, without disturbing the caller's locks.
+    ctx->EnsureEntitySynced(entity);
+}
+
+///@ ExportMethod
 FO_SCRIPT_API void Server_Game_SyncRelease(ServerEngine* server)
 {
     auto* ctx = server->GetCurrentSyncContext();

--- a/Source/Scripting/ServerGlobalScriptMethods.cpp
+++ b/Source/Scripting/ServerGlobalScriptMethods.cpp
@@ -1513,16 +1513,6 @@ FO_SCRIPT_API void Server_Game_SyncEnsure(ServerEngine* server, ServerEntity* en
 {
     auto* ctx = server->GetCurrentSyncContext();
     FO_VERIFY_AND_THROW(ctx, "Missing script execution context");
-
-    // Additive cover widen. Unlike Sync (which releases-and-reacquires the whole held set on a
-    // yield-on-sync boundary and is therefore Async), EnsureEntitySynced only *widens* the held set
-    // through the non-parking TryAcquire / AcquireLocks path: it never enqueues and never suspends
-    // the coroutine, so this export is not Async and is callable from synchronous code. In the fully
-    // unrestricted/auto-lock context it is a no-op (a synchronous caller relying on per-property
-    // auto-locking keeps that behaviour); in a restricted context (held entity locks and/or
-    // Game.Lock()) it adds the entity to the held set without dropping the caller's existing cover.
-    // This lets a cross-entity reader (e.g. the analytics emit) stay correct when invoked from a
-    // coroutine that resumed in a partial cover, without disturbing the caller's locks.
     ctx->EnsureEntitySynced(entity);
 }
 


### PR DESCRIPTION
Restores the additive **`Game.SyncEnsure(entity)`** server-script export (thin wrapper over the existing internal `SyncContext::EnsureEntitySynced`).

**Why:** the analytics events cleanup (lastfrontierdev/lf#234) emits cross-entity events from coroutines that may resume in a *partial* sync cover (e.g. post-yield `{player, critter}`), where reading the critter's map/location or the group leader would otherwise throw "Entity access without sync". `Game.Sync` can't be used there: it *replaces* the held set, is `Async`, and throws while a singleton lock (`Game.Lock()`) is held. `SyncEnsure` only *widens* the held set via the non-parking `TryAcquire`/`AcquireLocks` path — a no-op in the unrestricted auto-lock context, additive in a restricted one — and never suspends the coroutine, so it is **not** `Async` and is callable from synchronous code.

This export previously lived on the engine analytics branch; it was lost when lastfrontierdev/lf's analytics branch rebased its Engine submodule onto `master`. Re-adding it on `master` is the agreed path (owner decision: «Delay A») so the game code stays simple and non-async.

**Scope:** +18 lines, one export in `ServerGlobalScriptMethods.cpp`. No serialized-contract change — no compatibility-version bump. Codegen regenerates the `Game.SyncEnsure` binding.

**Merge order:** merge this **first**; then lastfrontierdev/lf#234's Engine submodule is pointed at `master`'s new tip and the game PR follows.