### PR TITLE
Sprite companions

### DIFF
--- a/Docs/BakingPipeline.md
+++ b/Docs/BakingPipeline.md
@@ -601,6 +601,54 @@ by the sequence name. BAM options accept a cycle index and optional cycle-frame
 selector separated by `-` (for example `$1` or `$1-3`); out-of-range cycle and
 frame selectors fall back to the first available cycle/frame.
 
+An image may carry **companion planes**: extra per-pixel channels of the sprite
+itself, placed beside it as `<name>.depth.png` and `<name>.normal.png`. They are
+not sprites and never bake as such — `ImageBaker` excludes any path whose stem
+ends in `.depth` or `.normal` from discovery, because the loader map is keyed on
+the last extension alone and cannot express a compound suffix. `LoadPng` folds
+whichever companions exist into the frame it is loading, and they follow that
+frame through padding and mesh cropping; a plane left untransformed would still
+satisfy its own size check while describing the wrong pixels.
+
+Both companions are ordinary images, because they are intermediates the baker
+re-encodes rather than textures the engine samples. Depth is a 16-bit greyscale
+PNG — the form a viewer shows as a depth map — whose values span that frame's own
+metre range rather than one absolute scale: a scale wide enough for a building
+leaves a prop using a few per cent of the sixteen bits. The range travels in the
+PNG's `DepthNearMetres` / `DepthFarMetres` text chunks and is written into the blob
+as two `float32` per frame, so values stay comparable between sprites. It is read
+through `LoadCompanionImage`, whose `keep_grey16` mode suppresses the
+`png_set_strip_16` the shared `PngLoad` applies and would leave only the high byte.
+Normals are an RGBA PNG in the usual 0.5-centred camera-space encoding. Both may
+carry alpha, and both are expected to: it matches the sprite's own coverage so the
+files composite with the same soft edge, and for normals it also separates
+background from data, which black alone cannot do since it decodes to a plausible
+vector. That alpha is descriptive only — the baker drops it, because the frame's
+own alpha is the single source of truth for coverage.
+
+The baker packs the pair into **one RGBA quad per pixel** at load time, so the
+shipped plane is uploaded into a texture with no per-pixel work and sampled with
+the sprite's own texture coordinates. `r`/`g` hold the camera-space normal in
+hemi-octahedral form and `b`/`a` hold the depth as a big-endian pair; the exact
+encode and its decode are written out at the top of `SpriteResource.h`. Two
+channels suffice for a normal because a unit vector has two degrees of freedom and
+the third is not even ambiguous here — every visible surface faces the camera — and
+that frees the byte the depth would otherwise have lost. Splitting depth across two
+channels survives bilinear filtering intact, since the decode is linear and the
+hardware filters each channel independently in floating point.
+
+Packing at load rather than at write time also keeps the rest of the pipeline
+simple: one plane the same width as the pixels travels through padding and mesh
+cropping, instead of two with their own element sizes.
+
+In the baked blob each frame writes a single presence flag after its pixel payload,
+followed by the two `float32` bounds and the packed plane when present;
+`SpriteResourceFrameData` exposes it as `Surface`. Adding it moved
+`SPRITE_RESOURCE_VERSION` to `4`; there is no fallback for the older layout. The
+format is pinned end to end by the `SpriteCompanionsArePackedIntoOneSurfaceQuad`
+section of `Test_ImageBaker.cpp`, which bakes authored companions and decodes the
+result back to metres and normals.
+
 `ImageBaker` can also bake an indexed silhouette mesh for every unique RGBA
 frame. The controls live in the dedicated `SpriteMesh.*` setting group inherited
 by `BakingSettings`:

--- a/Source/Common/Common.h
+++ b/Source/Common/Common.h
@@ -43,7 +43,7 @@
 FO_BEGIN_NAMESPACE
 
 // Force change of compatability version
-///@ MigrationRule Version 0 0 42
+///@ MigrationRule Version 0 0 43
 
 extern auto IsPackaged() -> bool;
 extern auto GetPackagedRuntimeName() -> string;

--- a/Source/Common/SpriteResource.cpp
+++ b/Source/Common/SpriteResource.cpp
@@ -107,6 +107,22 @@ auto ReadSpriteResource(const_span<uint8_t> data) -> SpriteResourceData
             frame_info.Size = frame.Size;
             frame_info.NextOffset = frame.NextOffset;
             frame.Pixels = read_sprite_pixels(frame.Size);
+
+            uint8_t has_surface = reader.GetUInt8();
+            FO_VERIFY_AND_THROW(has_surface <= 1, "Sprite frame surface flag is invalid", has_surface);
+
+            if (has_surface == 1) {
+                size_t surface_count = numeric_cast<size_t>(frame.Size.width) * frame.Size.height;
+                size_t remaining_size = reader.GetSize() - reader.GetCurPos();
+                FO_VERIFY_AND_THROW(surface_count * sizeof(ucolor) <= remaining_size, "Sprite frame surface data is truncated", surface_count, remaining_size, frame.Size);
+
+                frame.DepthNear = std::bit_cast<float32_t>(reader.GetLEUInt32());
+                frame.DepthFar = std::bit_cast<float32_t>(reader.GetLEUInt32());
+                FO_VERIFY_AND_THROW(frame.DepthFar > frame.DepthNear, "Sprite frame depth range is not increasing", frame.DepthNear, frame.DepthFar);
+                frame.Surface.resize(surface_count);
+                reader.ReadObjectArray(span<ucolor> {frame.Surface});
+            }
+
             frame.Mesh = ReadSpriteFrameMesh(reader, frame.Size);
         }
     }

--- a/Source/Common/SpriteResource.h
+++ b/Source/Common/SpriteResource.h
@@ -40,7 +40,35 @@
 FO_BEGIN_NAMESPACE
 
 constexpr uint8_t SPRITE_RESOURCE_MAGIC = 43;
-constexpr uint8_t SPRITE_RESOURCE_VERSION = 2;
+constexpr uint8_t SPRITE_RESOURCE_VERSION = 4;
+
+// A sprite may carry a per-pixel surface plane, baked from the `<name>.depth.png` and
+// `<name>.normal.png` companions placed beside the source image. It describes the geometry the flat
+// image stands for, so a shader can light it and sort it in depth rather than treat it as a decal.
+//
+// The two companions are packed into one RGBA quad per pixel, laid out to be uploaded into a texture
+// with no per-pixel work at load time and sampled with the sprite's own texture coordinates:
+//
+//   r, g  camera-space unit normal, hemi-octahedral. Only two channels because a unit vector has two
+//         degrees of freedom, and the third is not even ambiguous here: every normal faces the
+//         camera, so the sign is known. Decode:
+//             e = vec2(r, g) * 2 - 1
+//             p = vec2(e.x + e.y, e.x - e.y) * 0.5
+//             n = normalize(vec3(p, 1 - abs(p.x) - abs(p.y)))
+//             n.z = -n.z
+//   b, a  distance along the view ray, as a big-endian pair spanning this frame's own range:
+//             metres = DepthNear + (b * 256 + a) / 65535 * (DepthFar - DepthNear)
+//
+// Depth is normalised per frame rather than on one absolute scale, because a scale wide enough for a
+// building leaves a prop occupying a few per cent of the sixteen bits. The two bounds below make the
+// values comparable across sprites again, at eight bytes per frame.
+//
+// The split of depth across two channels survives bilinear filtering intact: the decode is linear
+// and the hardware filters each channel independently in floating point, so filtering the pair and
+// then decoding equals decoding and then filtering.
+//
+// Coverage is deliberately absent - the frame's own alpha is the single source of truth for what is
+// solid, and a transparent pixel has no surface to describe.
 
 enum class SpriteMeshKind : uint8_t
 {
@@ -64,6 +92,11 @@ struct SpriteResourceFrameData
     isize32 Size {};
     ipos32 NextOffset {};
     vector<ucolor> Pixels {};
+    // Empty when the source had no companions. Otherwise one entry per pixel, in the same row-major
+    // order as Pixels, packed as described at the top of this file.
+    vector<ucolor> Surface {};
+    float32_t DepthNear {};
+    float32_t DepthFar {};
     optional<SpriteMeshData> Mesh {};
 };
 

--- a/Source/Tests/Test_BakerHelpers.h
+++ b/Source/Tests/Test_BakerHelpers.h
@@ -274,6 +274,8 @@ namespace BakerTests
                 writer.Write<uint8_t>(uint8_t {255});
             }
 
+            writer.Write<uint8_t>(uint8_t {0}); // No surface plane
+
             // The mesh descriptor belongs to the frame, so it is written per frame rather than once
             writer.Write<uint8_t>(static_cast<uint8_t>(SpriteMeshKind::Quad));
         }
@@ -312,6 +314,7 @@ namespace BakerTests
             writer.Write<uint8_t>(uint8_t {255}); // A
         }
 
+        writer.Write<uint8_t>(uint8_t {0}); // No surface plane
         writer.Write<uint8_t>(static_cast<uint8_t>(mesh_kind));
 
         if (mesh_kind == SpriteMeshKind::Mesh) {

--- a/Source/Tests/Test_ClientEngine.cpp
+++ b/Source/Tests/Test_ClientEngine.cpp
@@ -3327,7 +3327,10 @@ TEST_CASE("DefaultSpriteFactoryValidatesBakedMeshPayload")
     cropped_mesh.SourceOffset = {1, -1};
     cropped_mesh.Vertices = {{0, 0}, {3, 0}, {0, 3}};
     cropped_mesh.Indices = {0, 1, 2};
-    constexpr size_t mesh_kind_offset = 20 + 2 * 2 * sizeof(ucolor);
+    // Header and frame fields, then the pixels, then the surface-plane presence flag - absent
+    // here, so a single byte - and only then the mesh descriptor.
+    constexpr size_t surface_flag_size = 1;
+    constexpr size_t mesh_kind_offset = 20 + 2 * 2 * sizeof(ucolor) + surface_flag_size;
     constexpr size_t mesh_vertex_count_offset = mesh_kind_offset + 1;
     constexpr size_t mesh_index_count_offset = mesh_vertex_count_offset + sizeof(uint16_t);
     constexpr size_t mesh_source_size_offset = mesh_index_count_offset + sizeof(uint32_t);

--- a/Source/Tests/Test_Common.cpp
+++ b/Source/Tests/Test_Common.cpp
@@ -293,6 +293,7 @@ TEST_CASE("SpriteResourceDecoderReadsCompleteResource")
     writer.Write<int16_t>(int16_t {5});
     writer.Write<int16_t>(int16_t {-6});
     writer.WriteObjectVector(pixels);
+    writer.Write<uint8_t>(uint8_t {0}); // No surface plane
     writer.Write<uint8_t>(static_cast<uint8_t>(SpriteMeshKind::Mesh));
     writer.Write<uint16_t>(uint16_t {3});
     writer.Write<uint32_t>(uint32_t {3});

--- a/Source/Tests/Test_ImageBaker.cpp
+++ b/Source/Tests/Test_ImageBaker.cpp
@@ -352,6 +352,96 @@ static void AppendFrmFrames(vector<uint8_t>& data, const vector<FrmFrameSpec>& f
     };
 }
 
+[[nodiscard]] static auto DecodeSurfaceDepth(const vector<uint8_t>& surface, size_t index, float32_t near_metres, float32_t far_metres) -> float32_t
+{
+    uint32_t packed = numeric_cast<uint32_t>(surface[index * 4 + 2]) * 256u + surface[index * 4 + 3];
+
+    return near_metres + numeric_cast<float32_t>(packed) / 65535.0f * (far_metres - near_metres);
+}
+
+[[nodiscard]] static auto DecodeSurfaceNormal(const vector<uint8_t>& surface, size_t index) -> tuple<float32_t, float32_t, float32_t>
+{
+    float32_t ex = numeric_cast<float32_t>(surface[index * 4 + 0]) / 255.0f * 2.0f - 1.0f;
+    float32_t ey = numeric_cast<float32_t>(surface[index * 4 + 1]) / 255.0f * 2.0f - 1.0f;
+    float32_t px = (ex + ey) * 0.5f;
+    float32_t py = (ex - ey) * 0.5f;
+    float32_t pz = std::max(0.0f, 1.0f - std::abs(px) - std::abs(py));
+    float32_t length = std::sqrt(px * px + py * py + pz * pz);
+
+    return {px / length, py / length, -pz / length};
+}
+
+[[nodiscard]] static auto PngCrc32(const_span<uint8_t> data) -> uint32_t
+{
+    uint32_t crc = 0xFFFFFFFFu;
+
+    for (uint8_t byte : data) {
+        crc ^= byte;
+
+        for (int32_t bit = 0; bit < 8; bit++) {
+            if ((crc & 1u) != 0u) {
+                crc = (crc >> 1u) ^ 0xEDB88320u;
+            }
+            else {
+                crc >>= 1u;
+            }
+        }
+    }
+
+    return crc ^ 0xFFFFFFFFu;
+}
+
+static void AppendPngChunk(vector<uint8_t>& png, string_view type, const vector<uint8_t>& payload)
+{
+    vector<uint8_t> body;
+    body.insert(body.end(), type.begin(), type.end());
+    body.insert(body.end(), payload.begin(), payload.end());
+
+    AppendBe32(png, numeric_cast<uint32_t>(payload.size()));
+    png.insert(png.end(), body.begin(), body.end());
+    AppendBe32(png, PngCrc32(body));
+}
+
+// Builds a PNG the way the art pipeline writes companions, which no image library bundled here can
+// produce: 16-bit greyscale plus alpha, carrying the metre range in text chunks.
+[[nodiscard]] static auto MakeCompanionPng(uint16_t width, uint16_t height, uint8_t bit_depth, uint8_t color_type, const vector<uint8_t>& samples, const vector<pair<string, string>>& text) -> vector<uint8_t>
+{
+    size_t channels = color_type == 6 ? 4 : 2;
+    size_t row_size = numeric_cast<size_t>(width) * channels * (bit_depth / 8);
+
+    vector<uint8_t> raw;
+
+    for (uint16_t y = 0; y < height; y++) {
+        raw.emplace_back(uint8_t {0});
+        raw.insert(raw.end(), samples.begin() + numeric_cast<ptrdiff_t>(numeric_cast<size_t>(y) * row_size), samples.begin() + numeric_cast<ptrdiff_t>((numeric_cast<size_t>(y) + 1) * row_size));
+    }
+
+    vector<uint8_t> header;
+    AppendBe32(header, width);
+    AppendBe32(header, height);
+    header.emplace_back(bit_depth);
+    header.emplace_back(color_type);
+    header.emplace_back(uint8_t {0});
+    header.emplace_back(uint8_t {0});
+    header.emplace_back(uint8_t {0});
+
+    vector<uint8_t> png = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    AppendPngChunk(png, "IHDR", header);
+
+    for (const auto& [keyword, value] : text) {
+        vector<uint8_t> payload;
+        payload.insert(payload.end(), keyword.begin(), keyword.end());
+        payload.emplace_back(uint8_t {0});
+        payload.insert(payload.end(), value.begin(), value.end());
+        AppendPngChunk(png, "tEXt", payload);
+    }
+
+    AppendPngChunk(png, "IDAT", Compressor::Compress(raw));
+    AppendPngChunk(png, "IEND", {});
+
+    return png;
+}
+
 [[nodiscard]] static auto MakeRix() -> vector<uint8_t>
 {
     vector<uint8_t> data;
@@ -846,6 +936,20 @@ static void AddSourceBinaryFile(BakerTests::TestRig& rig, string_view path, cons
 
 static void ReadSpriteMesh(DataReader& reader, BakedImageFrame& frame)
 {
+    // The surface plane precedes the mesh descriptor: a flag, then the depth bounds and one packed
+    // quad per pixel when present.
+    uint8_t has_surface = reader.Read<uint8_t>();
+    REQUIRE(has_surface <= 1);
+
+    if (has_surface == 1) {
+        (void)reader.Read<float32_t>();
+        (void)reader.Read<float32_t>();
+
+        for (size_t i = 0; i < numeric_cast<size_t>(frame.Width) * frame.Height * 4; i++) {
+            (void)reader.Read<uint8_t>();
+        }
+    }
+
     uint8_t mesh_kind = reader.Read<uint8_t>();
     REQUIRE(mesh_kind <= static_cast<uint8_t>(SpriteMeshKind::Mesh));
     frame.MeshKind = static_cast<SpriteMeshKind>(mesh_kind);
@@ -2581,6 +2685,96 @@ Frm=one.toy
         vector<SpriteInfoFileEntry> entries = ReadSpriteInfoFile("SpriteInfo/TestPack.foinfo", string(sprite_info_data.begin(), sprite_info_data.end()));
         REQUIRE(entries.size() == 1);
         CHECK(entries.front().SourcePath == "gfx/current.tga");
+    }
+
+    SECTION("SpriteCompanionsArePackedIntoOneSurfaceQuad")
+    {
+        // The shipped depth and normal companions are folded into a single RGBA quad per pixel so the
+        // client can hand the plane straight to a texture. This pins the packing a shader will decode
+        // against: depth must survive to the bit, and the normal must survive the drop from three
+        // channels to two, which is only possible because it always faces the camera.
+        constexpr uint16_t width = 2;
+        constexpr uint16_t height = 1;
+        constexpr float32_t near_metres = 1.0f;
+        constexpr float32_t far_metres = 3.0f;
+
+        vector<uint8_t> sprite_pixels = {200, 100, 50, 255, //
+            10, 20, 30, 255};
+        // 16-bit big-endian greyscale plus alpha. Both values are deliberately lopsided between their
+        // bytes, and the second is a single step away from the near plane: a byte-swapped or 8-bit
+        // encoding cannot reproduce either.
+        vector<uint8_t> depth_samples = {0xC0, 0x00, 0xFF, 0xFF, //
+            0x00, 0x40, 0xFF, 0xFF};
+        // Straight at the camera, then a corner facing equally along all three axes - which encodes to
+        // two visibly different channels, so a swapped pair cannot pass unnoticed.
+        vector<uint8_t> normal_samples = {128, 128, 0, 255, //
+            201, 201, 54, 255};
+
+        TestRig rig;
+        AddSourceBinaryFile(rig, "gfx/prop.png", MakeCompanionPng(width, height, 8, 6, sprite_pixels, {}));
+        AddSourceBinaryFile(rig, "gfx/prop.depth.png", MakeCompanionPng(width, height, 16, 4, depth_samples, {{"DepthNearMetres", "1.0"}, {"DepthFarMetres", "3.0"}}));
+        AddSourceBinaryFile(rig, "gfx/prop.normal.png", MakeCompanionPng(width, height, 8, 6, normal_samples, {}));
+
+        ImageBaker baker {rig.MakeContext()};
+        baker.BakeFiles(rig.GetAllSourceFiles(), "gfx/prop.png");
+
+        REQUIRE(rig.Outputs.count("gfx/prop.png") == 1);
+        DataReader reader {rig.Outputs.at("gfx/prop.png")};
+        CHECK(reader.Read<uint8_t>() == SPRITE_RESOURCE_MAGIC);
+        CHECK(reader.Read<uint8_t>() == SPRITE_RESOURCE_VERSION);
+        (void)reader.Read<uint16_t>();
+        (void)reader.Read<uint16_t>();
+        (void)reader.Read<uint8_t>();
+        (void)reader.Read<bool>();
+        (void)reader.Read<int16_t>();
+        (void)reader.Read<int16_t>();
+        uint16_t baked_width = reader.Read<uint16_t>();
+        uint16_t baked_height = reader.Read<uint16_t>();
+        (void)reader.Read<int16_t>();
+        (void)reader.Read<int16_t>();
+
+        size_t pixel_count = numeric_cast<size_t>(baked_width) * baked_height;
+        auto pixels = reader.ReadBytes(pixel_count * 4);
+
+        uint8_t has_surface = reader.Read<uint8_t>();
+        REQUIRE(has_surface == 1);
+        CHECK(reader.Read<float32_t>() == Catch::Approx(near_metres));
+        CHECK(reader.Read<float32_t>() == Catch::Approx(far_metres));
+
+        vector<uint8_t> surface;
+
+        for (size_t i = 0; i < pixel_count * 4; i++) {
+            surface.emplace_back(reader.Read<uint8_t>());
+        }
+
+        // Baking pads the frame with transparent margin, so the two authored pixels are found by
+        // their coverage rather than assumed to still sit at the start of the plane.
+        vector<size_t> opaque;
+
+        for (size_t i = 0; i < pixel_count; i++) {
+            if (pixels[i * 4 + 3] != 0) {
+                opaque.emplace_back(i);
+            }
+        }
+
+        REQUIRE(opaque.size() == 2);
+        size_t first = opaque[0];
+        size_t second = opaque[1];
+
+        // Depth is exact, not approximate: sixteen bits in, the same sixteen bits out. The second
+        // value sits 2 mm from the near plane, which a single byte could not even represent.
+        CHECK(DecodeSurfaceDepth(surface, first, near_metres, far_metres) == Catch::Approx(2.500038f).margin(1e-4));
+        CHECK(DecodeSurfaceDepth(surface, second, near_metres, far_metres) == Catch::Approx(1.001953f).margin(1e-4));
+
+        auto [first_x, first_y, first_z] = DecodeSurfaceNormal(surface, first);
+        CHECK(first_x == Catch::Approx(0.0f).margin(0.02));
+        CHECK(first_y == Catch::Approx(0.0f).margin(0.02));
+        CHECK(first_z == Catch::Approx(-1.0f).margin(0.02));
+
+        auto [second_x, second_y, second_z] = DecodeSurfaceNormal(surface, second);
+        CHECK(second_x == Catch::Approx(0.5774f).margin(0.02));
+        CHECK(second_y == Catch::Approx(0.5774f).margin(0.02));
+        CHECK(second_z == Catch::Approx(-0.5774f).margin(0.02));
     }
 
     SECTION("InvalidTgaInputsAreReported")

--- a/Source/Tools/ImageBaker.cpp
+++ b/Source/Tools/ImageBaker.cpp
@@ -43,9 +43,10 @@
 
 FO_BEGIN_NAMESPACE
 
-static auto PngLoad(ptr<const uint8_t> data, int32_t& result_width, int32_t& result_height) -> vector<uint8_t>;
+static auto PngLoad(ptr<const uint8_t> data, int32_t& result_width, int32_t& result_height, nptr<unordered_map<string, string>> text_chunks, bool keep_grey16) -> vector<uint8_t>;
 static auto TgaLoad(span<const uint8_t> data, int32_t& result_width, int32_t& result_height) -> vector<uint8_t>;
 
+static auto IsSpriteCompanionPath(string_view path) -> bool;
 static auto PadSpriteFrame(const ImageBaker::FrameShot& shot, int32_t padding) -> ImageBaker::FrameShot;
 static auto ResolveSpriteFramePadding(const ImageBaker::FrameShot& shot, const BakedSpriteMesh& mesh, int32_t build_padding) -> int32_t;
 static void TranslateSpriteMesh(BakedSpriteMesh& mesh, int32_t offset, const ImageBaker::FrameShot& shot);
@@ -193,6 +194,11 @@ void ImageBaker::BakeFiles(const FileCollection& files, string_view target_path)
                 if (file_ext != ext) {
                     continue;
                 }
+
+                if (IsSpriteCompanionPath(file_header.GetPath())) {
+                    continue;
+                }
+
                 current_sprite_sources.emplace(file_header.GetPath());
                 maximum_source_write_time = std::max(maximum_source_write_time, file_header.GetWriteTime());
                 if (scan_mode && _context->BakeChecker && !_context->BakeChecker(file_header.GetPath(), file_header.GetWriteTime())) {
@@ -207,6 +213,10 @@ void ImageBaker::BakeFiles(const FileCollection& files, string_view target_path)
         string ext = strex(target_path).get_file_extension();
 
         if (!_fileLoaders.contains(ext)) {
+            return;
+        }
+
+        if (IsSpriteCompanionPath(target_path)) {
             return;
         }
 
@@ -452,6 +462,16 @@ auto ImageBaker::BakeCollection(string_view fname, const FrameCollection& collec
                     writer.WriteBytes({bake_shot->Data.data(), bake_shot->Data.size()});
                 }
 
+                bool has_surface = !bake_shot->SurfaceData.empty();
+                writer.Write<uint8_t>(has_surface ? uint8_t {1} : uint8_t {0});
+
+                if (has_surface) {
+                    FO_VERIFY_AND_THROW(bake_shot->SurfaceData.size() == numeric_cast<size_t>(bake_shot->Width) * bake_shot->Height * 4, "Sprite frame surface plane size does not match frame dimensions", bake_shot->SurfaceData.size(), bake_shot->Width, bake_shot->Height);
+                    writer.Write<float32_t>(bake_shot->DepthNear);
+                    writer.Write<float32_t>(bake_shot->DepthFar);
+                    writer.WriteBytes({bake_shot->SurfaceData.data(), bake_shot->SurfaceData.size()});
+                }
+
                 writer.Write<uint8_t>(static_cast<uint8_t>(mesh.Kind));
 
                 if (mesh.Kind == SpriteMeshKind::Mesh) {
@@ -506,6 +526,18 @@ auto ImageBaker::BakeCollection(string_view fname, const FrameCollection& collec
     return sprite_info_entry;
 }
 
+static auto IsSpriteCompanionPath(string_view path) -> bool
+{
+    FO_NO_STACK_TRACE_ENTRY();
+
+    // Companions are extra channels of the sprite they are named after and must never bake as
+    // sprites of their own. The loader map is keyed on the last extension alone, so it cannot
+    // express `<name>.depth.png` and the exclusion has to be stated here.
+    string_view stem = strvex(path).erase_file_extension();
+
+    return stem.ends_with(".depth") || stem.ends_with(".normal");
+}
+
 static auto PadSpriteFrame(const ImageBaker::FrameShot& shot, int32_t padding) -> ImageBaker::FrameShot
 {
     FO_STACK_TRACE_ENTRY();
@@ -532,6 +564,22 @@ static auto PadSpriteFrame(const ImageBaker::FrameShot& shot, int32_t padding) -
         size_t source_offset = numeric_cast<size_t>(y) * source_row_size;
         size_t destination_offset = numeric_cast<size_t>(numeric_cast<int32_t>(y) + padding) * destination_row_size + destination_x_offset;
         MemCopy(result.Data.data() + destination_offset, shot.Data.data() + source_offset, source_row_size);
+    }
+
+    // The surface plane describes the same pixels and must land on the same grid; padding one without
+    // the other would shift depth and normals against colour by the padding width.
+    if (!shot.SurfaceData.empty()) {
+        FO_VERIFY_AND_THROW(shot.SurfaceData.size() == numeric_cast<size_t>(shot.Width) * shot.Height * 4, "Animation frame surface plane size does not match frame dimensions", shot.SurfaceData.size(), shot.Width, shot.Height);
+
+        result.SurfaceData.resize(numeric_cast<size_t>(result.Width) * result.Height * 4);
+        result.DepthNear = shot.DepthNear;
+        result.DepthFar = shot.DepthFar;
+
+        for (uint16_t y = 0; y < shot.Height; y++) {
+            size_t source_offset = numeric_cast<size_t>(y) * shot.Width * 4;
+            size_t destination_offset = (numeric_cast<size_t>(numeric_cast<int32_t>(y) + padding) * result.Width + numeric_cast<size_t>(padding)) * 4;
+            MemCopy(result.SurfaceData.data() + destination_offset, shot.SurfaceData.data() + source_offset, numeric_cast<size_t>(shot.Width) * 4);
+        }
     }
 
     return result;
@@ -625,6 +673,23 @@ static auto CropSpriteFrameToMeshBounds(const ImageBaker::FrameShot& shot, const
         size_t source_offset = source_y * source_row_size + source_x_offset;
         size_t destination_offset = numeric_cast<size_t>(y) * cropped_row_size;
         MemCopy(result.Data.data() + destination_offset, shot.Data.data() + source_offset, cropped_row_size);
+    }
+
+    // The surface plane is cropped to the same window as colour. A plane left at the original size
+    // would still pass its own size check against the pre-crop dimensions and describe wrong pixels.
+    if (!shot.SurfaceData.empty()) {
+        FO_VERIFY_AND_THROW(shot.SurfaceData.size() == numeric_cast<size_t>(shot.Width) * shot.Height * 4, "Animation frame surface plane size does not match frame dimensions", shot.SurfaceData.size(), shot.Width, shot.Height);
+
+        result.SurfaceData.resize(numeric_cast<size_t>(result.Width) * result.Height * 4);
+        result.DepthNear = shot.DepthNear;
+        result.DepthFar = shot.DepthFar;
+
+        for (uint16_t y = 0; y < result.Height; y++) {
+            size_t source_y = numeric_cast<size_t>(numeric_cast<int32_t>(y) + minimum_vertex.y);
+            size_t source_offset = (source_y * shot.Width + numeric_cast<size_t>(minimum_vertex.x)) * 4;
+            size_t destination_offset = numeric_cast<size_t>(y) * result.Width * 4;
+            MemCopy(result.SurfaceData.data() + destination_offset, shot.SurfaceData.data() + source_offset, numeric_cast<size_t>(result.Width) * 4);
+        }
     }
 
     return optional<ImageBaker::FrameShot> {std::move(result)};
@@ -2612,16 +2677,14 @@ auto ImageBaker::LoadPng(string_view fname, string_view opt, FileReader reader, 
 {
     FO_STACK_TRACE_ENTRY();
 
-    ignore_unused(fname);
     ignore_unused(opt);
-    ignore_unused(files);
 
     int32_t width = 0;
     int32_t height = 0;
     const_span<uint8_t> png_data = reader.GetDataSpan();
     FO_VERIFY_AND_THROW(!png_data.empty(), "PNG file has no data to load");
     auto png_data_ptr = make_ptr(png_data.data());
-    auto data = PngLoad(png_data_ptr, width, height);
+    auto data = PngLoad(png_data_ptr, width, height, nullptr, false);
 
     FrameCollection collection;
     collection.SequenceSize = 1;
@@ -2630,6 +2693,7 @@ auto ImageBaker::LoadPng(string_view fname, string_view opt, FileReader reader, 
     collection.Main.Frames[0].Width = numeric_cast<uint16_t>(width);
     collection.Main.Frames[0].Height = numeric_cast<uint16_t>(height);
     collection.Main.Frames[0].Data = std::move(data);
+    collection.Main.Frames[0].SurfaceData = LoadSurfaceCompanions(fname, files, {width, height}, collection.Main.Frames[0].DepthNear, collection.Main.Frames[0].DepthFar);
 
     return collection;
 }
@@ -2658,6 +2722,148 @@ auto ImageBaker::LoadTga(string_view fname, string_view opt, FileReader reader, 
     return collection;
 }
 
+auto ImageBaker::LoadSurfaceCompanions(string_view fname, const FileCollection& files, isize32 size, float32_t& near_metres, float32_t& far_metres) const -> vector<uint8_t>
+{
+    FO_STACK_TRACE_ENTRY();
+
+    vector<uint16_t> depth_plane = LoadDepthCompanion(fname, files, size, near_metres, far_metres);
+    vector<uint8_t> normal_plane = LoadNormalCompanion(fname, files, size);
+
+    if (depth_plane.empty() && normal_plane.empty()) {
+        return {};
+    }
+
+    // Depth is the half that cannot be defaulted: without it the two channels holding it have no
+    // range to be read against, while a missing normal is simply a surface facing the camera.
+    FO_VERIFY_AND_THROW(!depth_plane.empty(), "Sprite has a normal companion but no depth companion", fname);
+
+    auto encode_channel = [](float32_t value) -> uint8_t { return iround<uint8_t>(std::clamp(value * 0.5f + 0.5f, 0.0f, 1.0f) * 255.0f); };
+
+    size_t pixel_count = numeric_cast<size_t>(size.width) * size.height;
+    vector<uint8_t> surface_plane;
+    surface_plane.resize(pixel_count * 4);
+
+    for (size_t i = 0; i < pixel_count; i++) {
+        float32_t normal_x = 0.0f;
+        float32_t normal_y = 0.0f;
+        float32_t normal_z = 1.0f;
+
+        if (!normal_plane.empty()) {
+            normal_x = numeric_cast<float32_t>(normal_plane[i * 3 + 0]) / 255.0f * 2.0f - 1.0f;
+            normal_y = numeric_cast<float32_t>(normal_plane[i * 3 + 1]) / 255.0f * 2.0f - 1.0f;
+            // Mirrored into the upper hemisphere, which is what the octahedral fold below assumes;
+            // the sign is not information, every visible surface faces the camera.
+            normal_z = -(numeric_cast<float32_t>(normal_plane[i * 3 + 2]) / 255.0f * 2.0f - 1.0f);
+        }
+
+        float32_t fold = std::abs(normal_x) + std::abs(normal_y) + std::abs(normal_z);
+
+        if (fold > 0.0f) {
+            normal_x /= fold;
+            normal_y /= fold;
+        }
+        else {
+            normal_x = 0.0f;
+            normal_y = 0.0f;
+        }
+
+        uint16_t depth = depth_plane[i];
+        surface_plane[i * 4 + 0] = encode_channel(normal_x + normal_y);
+        surface_plane[i * 4 + 1] = encode_channel(normal_x - normal_y);
+        surface_plane[i * 4 + 2] = numeric_cast<uint8_t>(depth >> 8);
+        surface_plane[i * 4 + 3] = numeric_cast<uint8_t>(depth & 0xFF);
+    }
+
+    return surface_plane;
+}
+
+auto ImageBaker::LoadDepthCompanion(string_view fname, const FileCollection& files, isize32 size, float32_t& near_metres, float32_t& far_metres) const -> vector<uint16_t>
+{
+    FO_STACK_TRACE_ENTRY();
+
+    unordered_map<string, string> text_chunks;
+    vector<uint8_t> companion = LoadCompanionImage(fname, "depth", files, size, make_nptr(&text_chunks), true);
+
+    if (companion.empty()) {
+        return {};
+    }
+
+    // The metre range travels in the companion's own text chunks: the values span that sprite's
+    // depth rather than one absolute scale, so without the bounds they are a gradient with no units
+    // and two sprites cannot be compared.
+    auto near_entry = text_chunks.find("DepthNearMetres");
+    auto far_entry = text_chunks.find("DepthFarMetres");
+    FO_VERIFY_AND_THROW(near_entry != text_chunks.end() && far_entry != text_chunks.end(), "Sprite depth companion has no metre range", fname);
+    near_metres = strvex(near_entry->second).to_float32();
+    far_metres = strvex(far_entry->second).to_float32();
+    FO_VERIFY_AND_THROW(far_metres > near_metres, "Sprite depth companion range is not increasing", fname, near_metres, far_metres);
+
+    size_t pixel_count = numeric_cast<size_t>(size.width) * size.height;
+    FO_VERIFY_AND_THROW(companion.size() == pixel_count * sizeof(uint16_t), "Sprite depth companion must be a 16-bit greyscale image", fname, companion.size(), pixel_count);
+
+    vector<uint16_t> depth_plane;
+    depth_plane.resize(pixel_count);
+    MemCopy(depth_plane.data(), companion.data(), companion.size());
+
+    return depth_plane;
+}
+
+auto ImageBaker::LoadNormalCompanion(string_view fname, const FileCollection& files, isize32 size) const -> vector<uint8_t>
+{
+    FO_STACK_TRACE_ENTRY();
+
+    vector<uint8_t> companion = LoadCompanionImage(fname, "normal", files, size, nullptr, false);
+
+    if (companion.empty()) {
+        return {};
+    }
+
+    size_t pixel_count = numeric_cast<size_t>(size.width) * size.height;
+    vector<uint8_t> normal_plane;
+    normal_plane.resize(pixel_count * 3);
+
+    for (size_t i = 0; i < pixel_count; i++) {
+        if (companion[i * 4 + 3] != 0) {
+            normal_plane[i * 3 + 0] = companion[i * 4 + 0];
+            normal_plane[i * 3 + 1] = companion[i * 4 + 1];
+            normal_plane[i * 3 + 2] = companion[i * 4 + 2];
+        }
+        else {
+            // Facing the camera is the neutral answer where the companion describes nothing; the
+            // encoded zero vector it would otherwise carry reads as a black hole under any light.
+            normal_plane[i * 3 + 0] = 128;
+            normal_plane[i * 3 + 1] = 128;
+            normal_plane[i * 3 + 2] = 0;
+        }
+    }
+
+    return normal_plane;
+}
+
+auto ImageBaker::LoadCompanionImage(string_view fname, string_view kind, const FileCollection& files, isize32 size, nptr<unordered_map<string, string>> text_chunks, bool keep_grey16) const -> vector<uint8_t>
+{
+    FO_STACK_TRACE_ENTRY();
+
+    // A companion is an extra channel of the image it is named after, not a sprite of its own, so it
+    // travels as `<name>.<kind>.png` beside it and is folded into that sprite here.
+    File companion_file = files.FindFileByPath(strex("{}.{}.png", strvex(fname).erase_file_extension(), kind));
+
+    if (!companion_file) {
+        return {};
+    }
+
+    int32_t companion_width = 0;
+    int32_t companion_height = 0;
+    FileReader companion_reader = companion_file.GetReader();
+    const_span<uint8_t> companion_png = companion_reader.GetDataSpan();
+    FO_VERIFY_AND_THROW(!companion_png.empty(), "Sprite companion has no data to load", fname, kind);
+    auto companion_png_ptr = make_ptr(companion_png.data());
+    vector<uint8_t> companion_rgba = PngLoad(companion_png_ptr, companion_width, companion_height, text_chunks, keep_grey16);
+    FO_VERIFY_AND_THROW(companion_width == size.width && companion_height == size.height, "Sprite companion does not match its image size", fname, kind, companion_width, companion_height, size.width, size.height);
+
+    return companion_rgba;
+}
+
 static auto PngMalloc(png_structp png_ptr, png_alloc_size_t size) -> png_voidp
 {
     FO_NO_STACK_TRACE_ENTRY();
@@ -2674,7 +2880,7 @@ static void PngFree(png_structp png_ptr, png_voidp mem)
     SafeAlloc::FreeRaw(mem);
 }
 
-static auto PngLoad(ptr<const uint8_t> data, int32_t& result_width, int32_t& result_height) -> vector<uint8_t>
+static auto PngLoad(ptr<const uint8_t> data, int32_t& result_width, int32_t& result_height, nptr<unordered_map<string, string>> text_chunks, bool keep_grey16) -> vector<uint8_t>
 {
     FO_STACK_TRACE_ENTRY();
 
@@ -2734,8 +2940,23 @@ static auto PngLoad(ptr<const uint8_t> data, int32_t& result_width, int32_t& res
         int32_t color_type = 0;
         png_get_IHDR(png_ptr.get(), info_ptr.get(), &width, &height, &bit_depth, &color_type, nullptr, nullptr, nullptr);
 
+        // A companion depth plane is a 16-bit greyscale image and must keep both bytes; every other
+        // caller wants RGBA8, which is what stripping and the alpha filler produce.
+        // A companion depth plane is 16-bit greyscale, with or without the alpha it carries only so a
+        // viewer shows the same soft edge as the sprite. Coverage at runtime comes from the sprite's
+        // own alpha, so the companion's is dropped here rather than becoming a second opinion.
+        bool grey16 = keep_grey16 && bit_depth == 16 && (color_type == PNG_COLOR_TYPE_GRAY || color_type == PNG_COLOR_TYPE_GRAY_ALPHA);
+
         // Settings
-        png_set_strip_16(png_ptr.get());
+        if (grey16) {
+            if (color_type == PNG_COLOR_TYPE_GRAY_ALPHA) {
+                png_set_strip_alpha(png_ptr.get());
+            }
+        }
+        else {
+            png_set_strip_16(png_ptr.get());
+        }
+
         png_set_packing(png_ptr.get());
 
         if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8) {
@@ -2748,18 +2969,42 @@ static auto PngLoad(ptr<const uint8_t> data, int32_t& result_width, int32_t& res
             png_set_expand(png_ptr.get());
         }
 
-        png_set_filler(png_ptr.get(), 0x000000ff, PNG_FILLER_AFTER);
+        if (grey16) {
+            // PNG stores multi-byte samples big-endian; every other engine path is little-endian.
+            png_set_swap(png_ptr.get());
+        }
+        else {
+            png_set_filler(png_ptr.get(), 0x000000ff, PNG_FILLER_AFTER);
+        }
+
         png_read_update_info(png_ptr.get(), info_ptr.get());
+
+        // Companion planes carry their metre range here, so the caller can ask for the text chunks
+        // instead of needing a decoder of its own.
+        if (text_chunks) {
+            png_textp entries = nullptr;
+            int32_t entry_count = 0;
+            png_get_text(png_ptr.get(), info_ptr.get(), &entries, &entry_count);
+
+            for (int32_t i = 0; i < entry_count; i++) {
+                auto entry = make_ptr(entries).offset(i);
+
+                if (entry->key != nullptr && entry->text != nullptr) {
+                    text_chunks->emplace(string {entry->key}, string {entry->text});
+                }
+            }
+        }
 
         // Read
         vector<png_bytep> row_pointers;
         row_pointers.resize(height);
 
+        size_t sample_size = grey16 ? sizeof(uint16_t) : 4;
         vector<uint8_t> result;
-        result.resize(numeric_cast<size_t>(width) * height * 4);
+        result.resize(numeric_cast<size_t>(width) * height * sample_size);
 
         for (png_uint_32 i = 0; i < height; i++) {
-            auto row = make_ptr(result.data() + numeric_cast<size_t>(i) * numeric_cast<size_t>(width) * 4);
+            auto row = make_ptr(result.data() + numeric_cast<size_t>(i) * numeric_cast<size_t>(width) * sample_size);
             row_pointers[i] = row.get();
         }
 

--- a/Source/Tools/ImageBaker.h
+++ b/Source/Tools/ImageBaker.h
@@ -58,6 +58,14 @@ public:
         int16_t NextX {};
         int16_t NextY {};
         vector<uint8_t> Data {};
+        // The `<name>.depth.png` and `<name>.normal.png` companions, already packed into the shipped
+        // quad-per-pixel form, or empty when the source image had neither. Packed here at load rather
+        // than at write time so that every transform reshaping a frame reshapes one plane of the same
+        // width as the pixels, instead of two of their own.
+        vector<uint8_t> SurfaceData {};
+        // Metre bounds the depth values span; carried in the depth companion's text chunks.
+        float32_t DepthNear {};
+        float32_t DepthFar {};
         bool Shared {};
         uint16_t SharedIndex {};
     };
@@ -111,6 +119,10 @@ private:
     [[nodiscard]] auto LoadBam(string_view fname, string_view opt, FileReader reader, const FileCollection& files) const -> FrameCollection;
     [[nodiscard]] auto LoadPng(string_view fname, string_view opt, FileReader reader, const FileCollection& files) const -> FrameCollection;
     [[nodiscard]] auto LoadTga(string_view fname, string_view opt, FileReader reader, const FileCollection& files) const -> FrameCollection;
+    [[nodiscard]] auto LoadSurfaceCompanions(string_view fname, const FileCollection& files, isize32 size, float32_t& near_metres, float32_t& far_metres) const -> vector<uint8_t>;
+    [[nodiscard]] auto LoadDepthCompanion(string_view fname, const FileCollection& files, isize32 size, float32_t& near_metres, float32_t& far_metres) const -> vector<uint16_t>;
+    [[nodiscard]] auto LoadNormalCompanion(string_view fname, const FileCollection& files, isize32 size) const -> vector<uint8_t>;
+    [[nodiscard]] auto LoadCompanionImage(string_view fname, string_view kind, const FileCollection& files, isize32 size, nptr<unordered_map<string, string>> text_chunks, bool keep_grey16) const -> vector<uint8_t>;
 
     unordered_map<string, LoadFunc> _fileLoaders {};
 };


### PR DESCRIPTION
- Added support for companion planes in the baking pipeline, allowing depth and normal maps to be included with sprites.
- Updated `ImageBaker` to load and pack depth and normal companions into a single RGBA quad per pixel.
- Modified `SpriteResource` to accommodate new surface data, including depth bounds.
- Enhanced tests to validate the correct baking and decoding of companion planes.
- Incremented `SPRITE_RESOURCE_VERSION` to 4 to reflect changes in the resource format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sprite baking now supports matching `.depth.png` and `.normal.png` companion images.
  * Depth and normal data are combined into sprite surfaces and preserved through padding, cropping, and animation frames.
  * Depth metadata is retained for accurate per-frame depth ranges.
  * Missing normals default to camera-facing normals; invalid companion dimensions are rejected.

* **Documentation**
  * Added guidance covering companion-image baking and end-to-end validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->